### PR TITLE
Fix prod caching issue

### DIFF
--- a/components/map_display.py
+++ b/components/map_display.py
@@ -3,6 +3,41 @@ from streamlit_folium import folium_static
 from services.walkability import get_location, get_walkability_data, create_map, get_db_connection
 from tenacity import RetryError
 import os
+import json
+import psycopg2
+
+# #region agent log
+LOG_PATH = "/home/runner/workspace/.cursor/debug.log"
+def log_debug(location, message, data, hypothesis_id):
+    try:
+        with open(LOG_PATH, "a") as f:
+            f.write(json.dumps({
+                "location": location,
+                "message": message,
+                "data": data,
+                "timestamp": __import__("time").time() * 1000,
+                "sessionId": "debug-session",
+                "runId": "run1",
+                "hypothesisId": hypothesis_id
+            }) + "\n")
+    except:
+        pass
+# #endregion
+
+def _is_connection_closed(conn):
+    """
+    Check if a database connection is closed.
+    Works with both psycopg2 connections and Streamlit SQL connections.
+    """
+    if conn is None:
+        return True
+    # Check psycopg2 connection - most reliable method
+    if hasattr(conn, 'closed'):
+        return conn.closed
+    # For Streamlit SQL connections, we can't easily check without a query
+    # Return False (assume open) and let the actual query fail gracefully
+    # The exception handler will catch connection errors
+    return False
 
 @st.cache_resource
 def get_cached_db_connection():
@@ -10,14 +45,45 @@ def get_cached_db_connection():
     Get a cached database connection that persists across reruns.
     Uses @st.cache_resource to ensure the connection is reused efficiently.
     """
+    # #region agent log
+    log_debug("map_display.py:14", "get_cached_db_connection entry", {"has_pghost": bool(os.environ.get('PGHOST'))}, "A")
+    # #endregion
     if os.environ.get('PGHOST'):
-        return get_db_connection()
+        conn = get_db_connection()
+        # #region agent log
+        log_debug("map_display.py:17", "get_cached_db_connection created direct connection", {
+            "conn_id": id(conn),
+            "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
+            "conn_type": type(conn).__name__
+        }, "A")
+        # #endregion
+        return conn
     else:
         try:
-            return st.connection("postgresql", type="sql")
-        except Exception:
+            conn = st.connection("postgresql", type="sql")
+            # #region agent log
+            log_debug("map_display.py:21", "get_cached_db_connection created streamlit connection", {
+                "conn_id": id(conn),
+                "conn_type": type(conn).__name__
+            }, "A")
+            # #endregion
+            return conn
+        except Exception as e:
+            # #region agent log
+            log_debug("map_display.py:24", "get_cached_db_connection streamlit connection failed, using direct", {
+                "error": str(e)
+            }, "A")
+            # #endregion
             # If Streamlit connection fails, try direct connection
-            return get_db_connection()
+            conn = get_db_connection()
+            # #region agent log
+            log_debug("map_display.py:27", "get_cached_db_connection fallback direct connection", {
+                "conn_id": id(conn),
+                "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
+                "conn_type": type(conn).__name__
+            }, "A")
+            # #endregion
+            return conn
 
 @st.cache_data
 def cached_get_location(city_name):
@@ -29,8 +95,75 @@ def cached_get_walkability_data(city_name, buffer_radius_miles):
     Get walkability data using a cached database connection.
     Query results are cached separately from the connection.
     """
+    # #region agent log
+    log_debug("map_display.py:32", "cached_get_walkability_data entry", {
+        "city_name": city_name,
+        "buffer_radius_miles": buffer_radius_miles
+    }, "A")
+    # #endregion
     conn = get_cached_db_connection()
-    return get_walkability_data(city_name, buffer_radius_miles, conn)
+    # #region agent log
+    log_debug("map_display.py:35", "cached_get_walkability_data got connection", {
+        "conn_id": id(conn),
+        "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
+        "conn_type": type(conn).__name__,
+        "is_psycopg2": isinstance(conn, psycopg2.extensions.connection) if hasattr(psycopg2, 'extensions') else False
+    }, "A")
+    # #endregion
+    
+    # Check if connection is closed and clear cache if so
+    if _is_connection_closed(conn):
+        # #region agent log
+        log_debug("map_display.py:38", "cached_get_walkability_data connection is CLOSED, clearing cache", {
+            "conn_id": id(conn)
+        }, "A")
+        # #endregion
+        get_cached_db_connection.clear()
+        conn = get_cached_db_connection()
+        # #region agent log
+        log_debug("map_display.py:42", "cached_get_walkability_data got new connection after cache clear", {
+            "conn_id": id(conn),
+            "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+        }, "A")
+        # #endregion
+    
+    try:
+        result = get_walkability_data(city_name, buffer_radius_miles, conn)
+        # #region agent log
+        log_debug("map_display.py:48", "cached_get_walkability_data exit", {
+            "result_shape": result.shape if hasattr(result, 'shape') else None,
+            "conn_closed_after": conn.closed if hasattr(conn, 'closed') else None
+        }, "A")
+        # #endregion
+        return result
+    except (psycopg2.InterfaceError, psycopg2.OperationalError, psycopg2.DatabaseError) as e:
+        # #region agent log
+        log_debug("map_display.py:54", "cached_get_walkability_data connection error, clearing cache and retrying", {
+            "error_type": type(e).__name__,
+            "error_message": str(e)
+        }, "A")
+        # #endregion
+        # Connection error - clear cache and retry once
+        # This handles cases where connection was closed by server (timeout, idle cleanup, etc.)
+        try:
+            get_cached_db_connection.clear()
+            conn = get_cached_db_connection()
+            result = get_walkability_data(city_name, buffer_radius_miles, conn)
+            # #region agent log
+            log_debug("map_display.py:60", "cached_get_walkability_data retry successful", {
+                "result_shape": result.shape if hasattr(result, 'shape') else None
+            }, "A")
+            # #endregion
+            return result
+        except Exception as retry_error:
+            # #region agent log
+            log_debug("map_display.py:66", "cached_get_walkability_data retry also failed", {
+                "error_type": type(retry_error).__name__,
+                "error_message": str(retry_error)
+            }, "A")
+            # #endregion
+            # If retry also fails, re-raise the original error
+            raise e
 
 def render_main_content(city_name, buffer_radius_miles):
     if city_name:
@@ -46,8 +179,8 @@ def render_main_content(city_name, buffer_radius_miles):
 
         try:
             gdf = cached_get_walkability_data(city_name, buffer_radius_miles)
-        except ValueError as e:
-            st.error(str(e))
+        except (ValueError, psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+            st.error(f"Database error: {str(e)}")
             return
         
         m = create_map(location, gdf, buffer_size=buffer_radius_miles)

--- a/services/walkability.py
+++ b/services/walkability.py
@@ -8,6 +8,25 @@ from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_excep
 import math
 import psycopg2
 import os
+import json
+
+# #region agent log
+LOG_PATH = "/home/runner/workspace/.cursor/debug.log"
+def log_debug(location, message, data, hypothesis_id):
+    try:
+        with open(LOG_PATH, "a") as f:
+            f.write(json.dumps({
+                "location": location,
+                "message": message,
+                "data": data,
+                "timestamp": __import__("time").time() * 1000,
+                "sessionId": "debug-session",
+                "runId": "run1",
+                "hypothesisId": hypothesis_id
+            }) + "\n")
+    except:
+        pass
+# #endregion
 
 # Configure logging to output to a file
 logging.basicConfig(
@@ -172,10 +191,36 @@ def get_walkability_data(location_string, buffer_size, conn=None):
         # Direct psycopg2 connection (Replit PostgreSQL)
         # Note: If conn is provided, we use it (assumed to be cached/managed externally)
         # If None, we create a new one (for backward compatibility)
+        # #region agent log
+        log_debug("walkability.py:172", "get_walkability_data psycopg2 path entry", {
+            "conn_provided": conn is not None,
+            "conn_id": id(conn) if conn else None,
+            "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
+            "conn_type": type(conn).__name__ if conn else None
+        }, "A")
+        # #endregion
         should_close_conn = False
         if conn is None:
             conn = get_db_connection()
             should_close_conn = True
+            # #region agent log
+            log_debug("walkability.py:178", "get_walkability_data created new connection", {
+                "conn_id": id(conn),
+                "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+            }, "A")
+            # #endregion
+        
+        # #region agent log
+        if conn and hasattr(conn, 'closed'):
+            if conn.closed:
+                log_debug("walkability.py:185", "get_walkability_data connection CLOSED before cursor", {
+                    "conn_id": id(conn)
+                }, "A")
+            else:
+                log_debug("walkability.py:189", "get_walkability_data connection OPEN before cursor", {
+                    "conn_id": id(conn)
+                }, "A")
+        # #endregion
         
         try:
             query = """
@@ -195,20 +240,77 @@ def get_walkability_data(location_string, buffer_size, conn=None):
                 );
             """
             
+            # #region agent log
+            log_debug("walkability.py:198", "get_walkability_data about to create cursor", {
+                "conn_id": id(conn),
+                "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+            }, "A")
+            # #endregion
+            
+            # Check connection health before using it
+            if hasattr(conn, 'closed') and conn.closed:
+                # #region agent log
+                log_debug("walkability.py:203", "get_walkability_data connection closed before cursor creation", {
+                    "conn_id": id(conn)
+                }, "A")
+                # #endregion
+                raise psycopg2.InterfaceError("Connection is closed")
+            
             with conn.cursor() as cursor:
+                # #region agent log
+                log_debug("walkability.py:200", "get_walkability_data cursor created successfully", {
+                    "conn_id": id(conn),
+                    "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+                }, "A")
+                # #endregion
                 cursor.execute(query, (longitude, latitude, buffer_radius_degrees))
+                # #region agent log
+                log_debug("walkability.py:203", "get_walkability_data query executed", {
+                    "conn_id": id(conn),
+                    "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+                }, "A")
+                # #endregion
                 columns = [desc[0] for desc in cursor.description]
                 rows = cursor.fetchall()
                 df = pd.DataFrame(rows, columns=columns)
+                # #region agent log
+                log_debug("walkability.py:207", "get_walkability_data data fetched", {
+                    "conn_id": id(conn),
+                    "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
+                    "row_count": len(rows)
+                }, "A")
+                # #endregion
             
             # Convert geometry bytes to GeoSeries
             # Handle memoryview objects from psycopg2 by converting to bytes
             geometry_data = df['geometry'].apply(lambda x: bytes(x) if isinstance(x, memoryview) else x)
             gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkb(geometry_data))
+        except Exception as e:
+            # #region agent log
+            log_debug("walkability.py:212", "get_walkability_data exception during query", {
+                "conn_id": id(conn) if conn else None,
+                "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
+                "error_type": type(e).__name__,
+                "error_message": str(e)
+            }, "A")
+            # #endregion
+            raise
         finally:
             # Only close if we created the connection ourselves
             if should_close_conn and conn:
+                # #region agent log
+                log_debug("walkability.py:220", "get_walkability_data closing connection", {
+                    "conn_id": id(conn),
+                    "conn_closed_before": conn.closed if hasattr(conn, 'closed') else None
+                }, "A")
+                # #endregion
                 conn.close()
+                # #region agent log
+                log_debug("walkability.py:225", "get_walkability_data connection closed", {
+                    "conn_id": id(conn),
+                    "conn_closed_after": conn.closed if hasattr(conn, 'closed') else None
+                }, "A")
+                # #endregion
     
     # Ensure numeric columns are properly typed (important for Folium Choropleth)
     # This handles cases where database returns strings or object types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of walkability data fetching and map rendering by making DB access resilient and observable.
> 
> - **Connection management:** New `@st.cache_resource` `get_cached_db_connection()` with fallback from Streamlit SQL to direct `psycopg2`; detects closed connections and clears cache.
> - **Resilience:** `cached_get_walkability_data` retries once on `psycopg2` connection errors and refreshes the cached connection; enhanced exception handling surfaces database errors to users.
> - **Psycopg2 path hardening:** In `get_walkability_data`, validates inputs, checks `conn.closed`, guards cursor creation, and converts WKB safely; only closes connections it creates.
> - **Diagnostics:** Adds lightweight `log_debug(...)` instrumentation throughout both modules for connection lifecycle and query stages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b98a39b58aeb10f834856cf84c5a54c658e6a64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->