### PR TITLE
Fix prod caching issue

### DIFF
--- a/components/map_display.py
+++ b/components/map_display.py
@@ -2,27 +2,42 @@ import streamlit as st
 from streamlit_folium import folium_static
 from services.walkability import get_location, get_walkability_data, create_map, get_db_connection
 from tenacity import RetryError
+import logging
 import os
 import json
+import sys
+import time
 import psycopg2
 
-# #region agent log
-LOG_PATH = "/home/runner/workspace/.cursor/debug.log"
-def log_debug(location, message, data, hypothesis_id):
+DEBUG_LOG_ENV = "WALKABILITY_DEBUG_LOG"
+_DEBUG_LOGGER = logging.getLogger("walkability.debug")
+
+def log_debug(location, message, data=None, hypothesis_id=None):
+    """Emit a structured debug log when WALKABILITY_DEBUG_LOG=1 is set."""
+    if os.environ.get(DEBUG_LOG_ENV) != "1":
+        return
+    if not _DEBUG_LOGGER.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(message)s",
+            stream=sys.stdout,
+        )
+    payload = {
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp_ms": int(time.time() * 1000),
+        "hypothesis_id": hypothesis_id,
+    }
     try:
-        with open(LOG_PATH, "a") as f:
-            f.write(json.dumps({
-                "location": location,
-                "message": message,
-                "data": data,
-                "timestamp": __import__("time").time() * 1000,
-                "sessionId": "debug-session",
-                "runId": "run1",
-                "hypothesisId": hypothesis_id
-            }) + "\n")
-    except:
-        pass
-# #endregion
+        _DEBUG_LOGGER.info(json.dumps(payload, default=str))
+    except (TypeError, ValueError) as exc:
+        fallback = {
+            "location": location,
+            "message": "debug log serialization failed",
+            "error": str(exc),
+        }
+        _DEBUG_LOGGER.info(json.dumps(fallback, default=str))
 
 def _is_connection_closed(conn):
     """
@@ -45,44 +60,34 @@ def get_cached_db_connection():
     Get a cached database connection that persists across reruns.
     Uses @st.cache_resource to ensure the connection is reused efficiently.
     """
-    # #region agent log
     log_debug("map_display.py:14", "get_cached_db_connection entry", {"has_pghost": bool(os.environ.get('PGHOST'))}, "A")
-    # #endregion
     if os.environ.get('PGHOST'):
         conn = get_db_connection()
-        # #region agent log
         log_debug("map_display.py:17", "get_cached_db_connection created direct connection", {
             "conn_id": id(conn),
             "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
             "conn_type": type(conn).__name__
         }, "A")
-        # #endregion
         return conn
     else:
         try:
             conn = st.connection("postgresql", type="sql")
-            # #region agent log
             log_debug("map_display.py:21", "get_cached_db_connection created streamlit connection", {
                 "conn_id": id(conn),
                 "conn_type": type(conn).__name__
             }, "A")
-            # #endregion
             return conn
         except Exception as e:
-            # #region agent log
             log_debug("map_display.py:24", "get_cached_db_connection streamlit connection failed, using direct", {
                 "error": str(e)
             }, "A")
-            # #endregion
             # If Streamlit connection fails, try direct connection
             conn = get_db_connection()
-            # #region agent log
             log_debug("map_display.py:27", "get_cached_db_connection fallback direct connection", {
                 "conn_id": id(conn),
                 "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
                 "conn_type": type(conn).__name__
             }, "A")
-            # #endregion
             return conn
 
 @st.cache_data
@@ -95,73 +100,57 @@ def cached_get_walkability_data(city_name, buffer_radius_miles):
     Get walkability data using a cached database connection.
     Query results are cached separately from the connection.
     """
-    # #region agent log
     log_debug("map_display.py:32", "cached_get_walkability_data entry", {
         "city_name": city_name,
         "buffer_radius_miles": buffer_radius_miles
     }, "A")
-    # #endregion
     conn = get_cached_db_connection()
-    # #region agent log
     log_debug("map_display.py:35", "cached_get_walkability_data got connection", {
         "conn_id": id(conn),
         "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
         "conn_type": type(conn).__name__,
         "is_psycopg2": isinstance(conn, psycopg2.extensions.connection) if hasattr(psycopg2, 'extensions') else False
     }, "A")
-    # #endregion
     
     # Check if connection is closed and clear cache if so
     if _is_connection_closed(conn):
-        # #region agent log
         log_debug("map_display.py:38", "cached_get_walkability_data connection is CLOSED, clearing cache", {
             "conn_id": id(conn)
         }, "A")
-        # #endregion
         get_cached_db_connection.clear()
         conn = get_cached_db_connection()
-        # #region agent log
         log_debug("map_display.py:42", "cached_get_walkability_data got new connection after cache clear", {
             "conn_id": id(conn),
             "conn_closed": conn.closed if hasattr(conn, 'closed') else None
         }, "A")
-        # #endregion
     
     try:
         result = get_walkability_data(city_name, buffer_radius_miles, conn)
-        # #region agent log
         log_debug("map_display.py:48", "cached_get_walkability_data exit", {
             "result_shape": result.shape if hasattr(result, 'shape') else None,
             "conn_closed_after": conn.closed if hasattr(conn, 'closed') else None
         }, "A")
-        # #endregion
         return result
     except (psycopg2.InterfaceError, psycopg2.OperationalError, psycopg2.DatabaseError) as e:
-        # #region agent log
         log_debug("map_display.py:54", "cached_get_walkability_data connection error, clearing cache and retrying", {
             "error_type": type(e).__name__,
             "error_message": str(e)
         }, "A")
-        # #endregion
         # Connection error - clear cache and retry once
         # This handles cases where connection was closed by server (timeout, idle cleanup, etc.)
         try:
             get_cached_db_connection.clear()
             conn = get_cached_db_connection()
             result = get_walkability_data(city_name, buffer_radius_miles, conn)
-            # #region agent log
             log_debug("map_display.py:60", "cached_get_walkability_data retry successful", {
                 "result_shape": result.shape if hasattr(result, 'shape') else None
             }, "A")
-            # #endregion
             return result
         except Exception as retry_error:
-            # #region agent log
             log_debug("map_display.py:66", "cached_get_walkability_data retry also failed", {
                 "error_type": type(retry_error).__name__,
                 "error_message": str(retry_error)
             }, "A")
-            # #endregion
             # If retry also fails, re-raise the original error
             raise e
 
@@ -179,7 +168,10 @@ def render_main_content(city_name, buffer_radius_miles):
 
         try:
             gdf = cached_get_walkability_data(city_name, buffer_radius_miles)
-        except (ValueError, psycopg2.InterfaceError, psycopg2.OperationalError) as e:
+        except ValueError as e:
+            st.error(str(e))
+            return
+        except (psycopg2.InterfaceError, psycopg2.OperationalError, psycopg2.DatabaseError) as e:
             st.error(f"Database error: {str(e)}")
             return
         

--- a/services/walkability.py
+++ b/services/walkability.py
@@ -9,32 +9,52 @@ import math
 import psycopg2
 import os
 import json
+import sys
+import time
 
-# #region agent log
-LOG_PATH = "/home/runner/workspace/.cursor/debug.log"
-def log_debug(location, message, data, hypothesis_id):
+DEBUG_LOG_ENV = "WALKABILITY_DEBUG_LOG"
+_DEBUG_LOGGER = logging.getLogger("walkability.debug")
+
+def log_debug(location, message, data=None, hypothesis_id=None):
+    """Emit a structured debug log when WALKABILITY_DEBUG_LOG=1 is set."""
+    if os.environ.get(DEBUG_LOG_ENV) != "1":
+        return
+    if not _DEBUG_LOGGER.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(message)s",
+            stream=sys.stdout,
+        )
+    payload = {
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp_ms": int(time.time() * 1000),
+        "hypothesis_id": hypothesis_id,
+    }
     try:
-        with open(LOG_PATH, "a") as f:
-            f.write(json.dumps({
-                "location": location,
-                "message": message,
-                "data": data,
-                "timestamp": __import__("time").time() * 1000,
-                "sessionId": "debug-session",
-                "runId": "run1",
-                "hypothesisId": hypothesis_id
-            }) + "\n")
-    except:
-        pass
-# #endregion
+        _DEBUG_LOGGER.info(json.dumps(payload, default=str))
+    except (TypeError, ValueError) as exc:
+        fallback = {
+            "location": location,
+            "message": "debug log serialization failed",
+            "error": str(exc),
+        }
+        _DEBUG_LOGGER.info(json.dumps(fallback, default=str))
 
-# Configure logging to output to a file
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    filename='walkability.log',
-    filemode='w'
-)
+def _is_connection_closed(conn):
+    """
+    Check if a database connection is closed.
+    Works with psycopg2 connections and safely ignores non-boolean mocks.
+    """
+    if conn is None:
+        return True
+    closed_value = getattr(conn, "closed", 0)
+    if isinstance(closed_value, bool):
+        return closed_value
+    if isinstance(closed_value, int):
+        return closed_value != 0
+    return False
 
 @retry(
     stop=stop_after_attempt(3), 
@@ -191,26 +211,21 @@ def get_walkability_data(location_string, buffer_size, conn=None):
         # Direct psycopg2 connection (Replit PostgreSQL)
         # Note: If conn is provided, we use it (assumed to be cached/managed externally)
         # If None, we create a new one (for backward compatibility)
-        # #region agent log
         log_debug("walkability.py:172", "get_walkability_data psycopg2 path entry", {
             "conn_provided": conn is not None,
             "conn_id": id(conn) if conn else None,
             "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
             "conn_type": type(conn).__name__ if conn else None
         }, "A")
-        # #endregion
         should_close_conn = False
         if conn is None:
             conn = get_db_connection()
             should_close_conn = True
-            # #region agent log
             log_debug("walkability.py:178", "get_walkability_data created new connection", {
                 "conn_id": id(conn),
                 "conn_closed": conn.closed if hasattr(conn, 'closed') else None
             }, "A")
-            # #endregion
         
-        # #region agent log
         if conn and hasattr(conn, 'closed'):
             if conn.closed:
                 log_debug("walkability.py:185", "get_walkability_data connection CLOSED before cursor", {
@@ -220,7 +235,6 @@ def get_walkability_data(location_string, buffer_size, conn=None):
                 log_debug("walkability.py:189", "get_walkability_data connection OPEN before cursor", {
                     "conn_id": id(conn)
                 }, "A")
-        # #endregion
         
         try:
             query = """
@@ -240,77 +254,61 @@ def get_walkability_data(location_string, buffer_size, conn=None):
                 );
             """
             
-            # #region agent log
             log_debug("walkability.py:198", "get_walkability_data about to create cursor", {
                 "conn_id": id(conn),
                 "conn_closed": conn.closed if hasattr(conn, 'closed') else None
             }, "A")
-            # #endregion
             
             # Check connection health before using it
-            if hasattr(conn, 'closed') and conn.closed:
-                # #region agent log
+            if _is_connection_closed(conn):
                 log_debug("walkability.py:203", "get_walkability_data connection closed before cursor creation", {
                     "conn_id": id(conn)
                 }, "A")
-                # #endregion
                 raise psycopg2.InterfaceError("Connection is closed")
             
             with conn.cursor() as cursor:
-                # #region agent log
                 log_debug("walkability.py:200", "get_walkability_data cursor created successfully", {
                     "conn_id": id(conn),
                     "conn_closed": conn.closed if hasattr(conn, 'closed') else None
                 }, "A")
-                # #endregion
                 cursor.execute(query, (longitude, latitude, buffer_radius_degrees))
-                # #region agent log
                 log_debug("walkability.py:203", "get_walkability_data query executed", {
                     "conn_id": id(conn),
                     "conn_closed": conn.closed if hasattr(conn, 'closed') else None
                 }, "A")
-                # #endregion
                 columns = [desc[0] for desc in cursor.description]
                 rows = cursor.fetchall()
                 df = pd.DataFrame(rows, columns=columns)
-                # #region agent log
                 log_debug("walkability.py:207", "get_walkability_data data fetched", {
                     "conn_id": id(conn),
                     "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
                     "row_count": len(rows)
                 }, "A")
-                # #endregion
             
             # Convert geometry bytes to GeoSeries
             # Handle memoryview objects from psycopg2 by converting to bytes
             geometry_data = df['geometry'].apply(lambda x: bytes(x) if isinstance(x, memoryview) else x)
             gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkb(geometry_data))
         except Exception as e:
-            # #region agent log
             log_debug("walkability.py:212", "get_walkability_data exception during query", {
                 "conn_id": id(conn) if conn else None,
                 "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
                 "error_type": type(e).__name__,
                 "error_message": str(e)
             }, "A")
-            # #endregion
             raise
         finally:
             # Only close if we created the connection ourselves
             if should_close_conn and conn:
-                # #region agent log
                 log_debug("walkability.py:220", "get_walkability_data closing connection", {
                     "conn_id": id(conn),
                     "conn_closed_before": conn.closed if hasattr(conn, 'closed') else None
                 }, "A")
-                # #endregion
                 conn.close()
-                # #region agent log
                 log_debug("walkability.py:225", "get_walkability_data connection closed", {
                     "conn_id": id(conn),
                     "conn_closed_after": conn.closed if hasattr(conn, 'closed') else None
                 }, "A")
-                # #endregion
     
     # Ensure numeric columns are properly typed (important for Folium Choropleth)
     # This handles cases where database returns strings or object types

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,7 @@ pytest --cov=services --cov-report=html
 - **Geocoding**: Location lookup with mocked Nominatim
 - **Data Fetching**: Database queries with mocked connections
 - **Map Creation**: Folium map generation with various inputs
+- **Connection Caching**: Database connection caching and error recovery (closed connection handling, retry logic)
 
 ## Adding New Tests
 

--- a/tests/test_connection_caching.py
+++ b/tests/test_connection_caching.py
@@ -1,0 +1,280 @@
+"""
+Tests for database connection caching and error recovery.
+These tests ensure that closed connections are detected and handled gracefully,
+preventing the "connection already closed" error in production.
+"""
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+import psycopg2
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Point
+from shapely import wkb
+
+# Import the functions we're testing
+from components.map_display import (
+    _is_connection_closed,
+    get_cached_db_connection,
+    cached_get_walkability_data
+)
+from services.walkability import get_walkability_data
+
+# Import the actual function implementations (not the cached wrappers)
+import components.map_display as map_display_module
+
+
+class TestConnectionClosedDetection:
+    """Test the _is_connection_closed helper function."""
+    
+    def test_is_connection_closed_none(self):
+        """Test that None connection is detected as closed."""
+        assert _is_connection_closed(None) is True
+    
+    def test_is_connection_closed_psycopg2_open(self):
+        """Test that open psycopg2 connection is detected as open."""
+        mock_conn = Mock()
+        mock_conn.closed = False
+        assert _is_connection_closed(mock_conn) is False
+    
+    def test_is_connection_closed_psycopg2_closed(self):
+        """Test that closed psycopg2 connection is detected as closed."""
+        mock_conn = Mock()
+        mock_conn.closed = True
+        assert _is_connection_closed(mock_conn) is True
+    
+    def test_is_connection_closed_streamlit_connection(self):
+        """Test that Streamlit SQL connection (without closed attr) returns False."""
+        # Streamlit connections don't have 'closed' attribute
+        # We assume they're open and let the query fail gracefully
+        mock_conn = Mock()
+        del mock_conn.closed  # Remove closed attribute if it exists
+        assert _is_connection_closed(mock_conn) is False
+
+
+class TestCachedConnection:
+    """Test the get_cached_db_connection caching behavior."""
+    
+    @patch('components.map_display.get_db_connection')
+    @patch('components.map_display.os.environ.get')
+    def test_get_cached_db_connection_creates_connection(self, mock_env_get, mock_get_db):
+        """Test that a new connection is created when cache is empty."""
+        mock_env_get.return_value = 'test_host'  # Simulate PGHOST set
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_get_db.return_value = mock_conn
+        
+        # Clear cache first
+        get_cached_db_connection.clear()
+        
+        conn = get_cached_db_connection()
+        
+        assert conn == mock_conn
+        mock_get_db.assert_called_once()
+    
+    @patch('components.map_display.get_db_connection')
+    @patch('components.map_display.os.environ.get')
+    def test_get_cached_db_connection_reuses_cached(self, mock_env_get, mock_get_db):
+        """Test that cached connection is reused on subsequent calls."""
+        mock_env_get.return_value = 'test_host'
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_get_db.return_value = mock_conn
+        
+        # Clear cache first
+        get_cached_db_connection.clear()
+        
+        # First call creates connection
+        conn1 = get_cached_db_connection()
+        # Second call should reuse cached connection
+        conn2 = get_cached_db_connection()
+        
+        assert conn1 == conn2
+        # Should only be called once due to caching
+        assert mock_get_db.call_count == 1
+    
+    @patch('components.map_display.st.connection')
+    @patch('components.map_display.os.environ.get')
+    def test_get_cached_db_connection_fallback_to_direct(self, mock_env_get, mock_st_conn):
+        """Test fallback to direct connection when Streamlit connection fails."""
+        mock_env_get.return_value = None  # No PGHOST, try Streamlit connection
+        
+        # Simulate Streamlit connection failure
+        mock_st_conn.side_effect = Exception("Connection failed")
+        
+        mock_direct_conn = Mock()
+        mock_direct_conn.closed = False
+        
+        with patch('components.map_display.get_db_connection', return_value=mock_direct_conn):
+            get_cached_db_connection.clear()
+            conn = get_cached_db_connection()
+            
+            assert conn == mock_direct_conn
+
+
+class TestCachedWalkabilityDataWithClosedConnection:
+    """Test cached_get_walkability_data handling of closed connections."""
+    
+    def setup_method(self):
+        """Clear caches before each test."""
+        get_cached_db_connection.clear()
+        cached_get_walkability_data.clear()
+    
+    def test_closed_connection_clears_cache_and_retries(self):
+        """Test that closed connection triggers cache clear and retry."""
+        # First connection is closed
+        closed_conn = Mock()
+        closed_conn.closed = True
+        
+        # Second connection (after cache clear) is open
+        open_conn = Mock()
+        open_conn.closed = False
+        
+        # Mock GeoDataFrame result
+        mock_gdf = gpd.GeoDataFrame({
+            'geoid20': ['123456789012'],
+            'natwalkind': [11.25],
+            'geometry': [Point(-83.9207, 35.9606).buffer(0.01)]
+        }, crs='EPSG:4326')
+        
+        # Patch the actual function calls inside the cached function
+        with patch('components.map_display.get_cached_db_connection', side_effect=[closed_conn, open_conn]):
+            with patch('components.map_display.get_walkability_data', return_value=mock_gdf) as mock_get_data:
+                result = cached_get_walkability_data("Knoxville, TN", 1.0)
+                
+                # Should have called get_walkability_data with the open connection
+                mock_get_data.assert_called_once_with("Knoxville, TN", 1.0, open_conn)
+                assert isinstance(result, gpd.GeoDataFrame)
+    
+    def test_interface_error_triggers_retry(self):
+        """Test that InterfaceError triggers cache clear and retry."""
+        # First connection causes InterfaceError
+        bad_conn = Mock()
+        bad_conn.closed = False
+        
+        # Second connection (after cache clear) works
+        good_conn = Mock()
+        good_conn.closed = False
+        
+        mock_gdf = gpd.GeoDataFrame({
+            'geoid20': ['123456789012'],
+            'natwalkind': [11.25],
+            'geometry': [Point(-83.9207, 35.9606).buffer(0.01)]
+        }, crs='EPSG:4326')
+        
+        with patch('components.map_display.get_cached_db_connection', side_effect=[bad_conn, good_conn]):
+            with patch('components.map_display.get_walkability_data', side_effect=[
+                psycopg2.InterfaceError("connection already closed"),
+                mock_gdf
+            ]) as mock_get_data:
+                result = cached_get_walkability_data("Knoxville, TN", 1.0)
+                
+                # Should have retried after clearing cache
+                assert mock_get_data.call_count == 2
+                assert isinstance(result, gpd.GeoDataFrame)
+    
+    def test_operational_error_triggers_retry(self):
+        """Test that OperationalError triggers cache clear and retry."""
+        bad_conn = Mock()
+        bad_conn.closed = False
+        good_conn = Mock()
+        good_conn.closed = False
+        
+        mock_gdf = gpd.GeoDataFrame({
+            'geoid20': ['123456789012'],
+            'natwalkind': [11.25],
+            'geometry': [Point(-83.9207, 35.9606).buffer(0.01)]
+        }, crs='EPSG:4326')
+        
+        with patch('components.map_display.get_cached_db_connection', side_effect=[bad_conn, good_conn]):
+            with patch('components.map_display.get_walkability_data', side_effect=[
+                psycopg2.OperationalError("server closed the connection"),
+                mock_gdf
+            ]) as mock_get_data:
+                result = cached_get_walkability_data("Knoxville, TN", 1.0)
+                
+                assert mock_get_data.call_count == 2
+                assert isinstance(result, gpd.GeoDataFrame)
+    
+    def test_retry_failure_raises_original_error(self):
+        """Test that if retry also fails, original error is raised."""
+        bad_conn = Mock()
+        bad_conn.closed = False
+        also_bad_conn = Mock()
+        also_bad_conn.closed = False
+        
+        original_error = psycopg2.InterfaceError("connection already closed")
+        retry_error = psycopg2.OperationalError("connection failed")
+        
+        with patch('components.map_display.get_cached_db_connection', side_effect=[bad_conn, also_bad_conn]):
+            with patch('components.map_display.get_walkability_data', side_effect=[original_error, retry_error]):
+                # Should raise the original error, not the retry error
+                with pytest.raises(psycopg2.InterfaceError) as exc_info:
+                    cached_get_walkability_data("Knoxville, TN", 1.0)
+                
+                assert str(exc_info.value) == "connection already closed"
+    
+    def test_successful_query_with_open_connection(self):
+        """Test normal successful flow with open connection."""
+        open_conn = Mock()
+        open_conn.closed = False
+        
+        mock_gdf = gpd.GeoDataFrame({
+            'geoid20': ['123456789012'],
+            'natwalkind': [11.25],
+            'geometry': [Point(-83.9207, 35.9606).buffer(0.01)]
+        }, crs='EPSG:4326')
+        
+        with patch('components.map_display.get_cached_db_connection', return_value=open_conn):
+            with patch('components.map_display.get_walkability_data', return_value=mock_gdf) as mock_get_data:
+                result = cached_get_walkability_data("Knoxville, TN", 1.0)
+                
+                # Should only call once (no retry needed)
+                mock_get_data.assert_called_once_with("Knoxville, TN", 1.0, open_conn)
+                assert isinstance(result, gpd.GeoDataFrame)
+
+
+class TestWalkabilityDataConnectionCheck:
+    """Test that get_walkability_data checks connection before use."""
+    
+    @patch('services.walkability.get_location', return_value=(-83.9207, 35.9606))
+    def test_get_walkability_data_raises_on_closed_connection(self, mock_get_location):
+        """Test that get_walkability_data raises InterfaceError for closed connection."""
+        closed_conn = Mock()
+        closed_conn.closed = True
+        # Ensure it doesn't have 'query' attribute so it goes to psycopg2 path
+        if hasattr(closed_conn, 'query'):
+            delattr(closed_conn, 'query')
+        
+        with pytest.raises(psycopg2.InterfaceError) as exc_info:
+            get_walkability_data("Knoxville, TN", 1.0, conn=closed_conn)
+        
+        assert "Connection is closed" in str(exc_info.value)
+    
+    @patch('services.walkability.get_location', return_value=(-83.9207, 35.9606))
+    def test_get_walkability_data_succeeds_with_open_connection(self, mock_get_location):
+        """Test that get_walkability_data works with open connection."""
+        open_conn = Mock()
+        open_conn.closed = False
+        # Ensure it doesn't have 'query' attribute so it goes to psycopg2 path
+        if hasattr(open_conn, 'query'):
+            delattr(open_conn, 'query')
+        
+        mock_cursor = Mock()
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=None)
+        open_conn.cursor.return_value = mock_cursor
+        
+        mock_cursor.description = [
+            ('geoid20',), ('d2a_ranked',), ('d2b_ranked'), 
+            ('d3b_ranked',), ('d4a_ranked',), ('natwalkind',), ('geometry',)
+        ]
+        mock_point = Point(-83.9207, 35.9606).buffer(0.01)
+        mock_cursor.fetchall.return_value = [
+            ('123456789012', 10, 12, 8, 15, 11.25, wkb.dumps(mock_point))
+        ]
+        
+        result = get_walkability_data("Knoxville, TN", 1.0, conn=open_conn)
+        
+        assert isinstance(result, gpd.GeoDataFrame)
+        assert 'geoid20' in result.columns
+        assert 'natwalkind' in result.columns

--- a/tests/test_connection_caching.py
+++ b/tests/test_connection_caching.py
@@ -265,7 +265,7 @@ class TestWalkabilityDataConnectionCheck:
         open_conn.cursor.return_value = mock_cursor
         
         mock_cursor.description = [
-            ('geoid20',), ('d2a_ranked',), ('d2b_ranked'), 
+            ('geoid20',), ('d2a_ranked',), ('d2b_ranked',),
             ('d3b_ranked',), ('d4a_ranked',), ('natwalkind',), ('geometry',)
         ]
         mock_point = Point(-83.9207, 35.9606).buffer(0.01)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens reliability around database access and observability.
> 
> - Adds structured JSON debug logging via `log_debug` gated by `WALKABILITY_DEBUG_LOG`, replacing file writes
> - Introduces `_is_connection_closed` and uses it to proactively detect closed connections in `get_walkability_data` and to clear/recreate cached connections in `cached_get_walkability_data`
> - Implements single-retry flow on `psycopg2` connection errors (Interface/Operational/Database) and splits UI error handling (`ValueError` vs DB errors) in `components/map_display.py`
> - Adds `tests/test_connection_caching.py` covering cache reuse, fallback behavior, closed-connection recovery, retry semantics, and success path; updates `tests/README.md` coverage list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcd0fc21b641fdd1e63d7d3e47ae2c00e3bb8943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->