### PR TITLE
Refactor database connection handling

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(python -c:*)",
+      "Bash(python:*)",
+      "Bash(pip:*)",
+      "Bash(.venv/Scripts/python:*)",
+      "Bash(.venv/Scripts/pip:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ streamlit run scripts/create_neo_postgres_db.py
 app.py                          # Entry point: page config + orchestrates sidebar/map
 ├── components/sidebar.py       # User inputs (address, buffer radius slider)
 ├── components/map_display.py   # Connection caching, data fetching, map rendering
-└── services/walkability.py     # Core logic: geocoding, DB queries, map creation
+└── services/
+    ├── db.py                   # Framework-agnostic DB connection factory (env vars only)
+    └── walkability.py          # Core logic: geocoding, DB queries, map creation
 ```
 
 **Request flow**: User enters address in sidebar → `map_display.py` calls geocoding and DB query (with `@st.cache_resource` caching) → `walkability.py` geocodes via Nominatim, runs PostGIS spatial query with buffer → returns GeoDataFrame → `map_display.py` renders Folium choropleth + data table.
@@ -58,24 +60,25 @@ app.py                          # Entry point: page config + orchestrates sideba
 
 ## Key Implementation Details
 
-- `walkability.py:get_db_connection()` tries Replit env vars first (`REPLIT_DB_URL`, `PGHOST`, etc.), then falls back to `.streamlit/secrets.toml`
-- `walkability.py:get_walkability_data()` handles both Streamlit SQL connections and direct psycopg2 connections, including memoryview-to-bytes conversion for geometry data
+- `db.py:get_db_connection()` reads `PG*` env vars exclusively (no Streamlit dependency). `validate_pg_env()` and `get_pg_env()` are reusable validators shared by scripts
+- `walkability.py:get_walkability_data()` accepts psycopg2 connections; if `conn=None` it creates and closes its own. Handles memoryview-to-bytes conversion for geometry data
 - `walkability.py:miles_to_degrees()` is latitude-aware (accounts for Earth curvature)
 - Buffer radius spatial queries use `ST_DWithin` against the PostGIS geometry column
 - Geocoding uses tenacity for retries on transient failures
 
 ## Testing
 
-Tests use `unittest.mock` throughout — no live database connection needed. Two test files:
+Tests use `unittest.mock` throughout — no live database connection needed. Three test files:
+- `tests/test_db.py` — env var validation, port parsing, connection factory, connection-closed detection
 - `tests/test_walkability.py` — input validation, coordinate math, geocoding, data queries, map creation
 - `tests/test_connection_caching.py` — connection lifecycle, cache clearing, closed connection recovery
 
 ## Configuration
 
+- `PG*` env vars (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`) — required by all services and scripts
 - `.streamlit/config.toml` — server runs headless on port 5000
-- `.streamlit/secrets.toml` (gitignored) — database credentials for Streamlit Cloud
 - `.env` (gitignored) — environment variables for local/Replit
-- Deployment targets: Replit (autoscale) and Streamlit Community Cloud
+- Deployment target: Replit (autoscale)
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ Replit PostgreSQL + PostGIS (national_walkability_index table)
 - `app.py` boots Streamlit, renders the sidebar controls, and streams results.
 - `components/sidebar.py` captures address/radius inputs and introduces the dataset.
 - `components/map_display.py` calls cached data services, creates a Folium map, and surfaces a data table.
-- `services/walkability.py` geocodes inputs with Nominatim, queries PostGIS via Streamlit's SQL connection, and renders Folium layers.
+- `services/db.py` provides the framework-agnostic database connection factory (env-var-based, no Streamlit dependency).
+- `services/walkability.py` geocodes inputs with Nominatim, queries PostGIS via psycopg2, and renders Folium layers.
 - `scripts/create_neo_postgres_db.py` loads the processed CSV into Replit PostgreSQL/PostGIS and maintains the spatial index.
-
-**Note on code organization:** The current `services/walkability.py` module handles multiple responsibilities (geocoding, validation, database connections, data fetching, and map creation) in a single file. This structure is functional and production-ready, but future iterations could benefit from splitting into focused modules (`geocoding.py`, `database.py`, `mapping.py`) for improved maintainability and testability as the codebase grows.
 
 ## Tech Stack
 | Area | Tools |
@@ -71,18 +70,7 @@ pip install -r requirements.txt
 ```
 
 ### 3. Configure database connection
-The app supports two connection methods:
-- **Replit PostgreSQL:** Set environment variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`)
-- **Streamlit secrets:** Create `.streamlit/secrets.toml` with your PostgreSQL credentials (replace placeholders):
-```toml
-[connections.postgresql]
-dialect = "postgresql"
-host = "YOUR_NEON_HOST"
-port = 5432
-database = "YOUR_DB"
-username = "YOUR_NEON_USER"
-password = "YOUR_NEON_PASSWORD"
-```
+Set the following environment variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`). All core services and scripts rely on these env vars exclusively — no Streamlit-specific configuration is required.
 
 ### 4. Load the walkability table (one-time setup only)
 > **Important:** The CSV file is only needed for initial database setup. Once the database is populated, you can remove the CSV file. The running application queries PostgreSQL directly and does not use the CSV file.

--- a/components/map_display.py
+++ b/components/map_display.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from streamlit_folium import folium_static
-from services.walkability import get_location, get_walkability_data, create_map, get_db_connection
+from services.walkability import get_location, get_walkability_data, create_map, get_db_connection, _is_connection_closed
 from tenacity import RetryError
 import logging
 import os
@@ -39,56 +39,20 @@ def log_debug(location, message, data=None, hypothesis_id=None):
         }
         _DEBUG_LOGGER.info(json.dumps(fallback, default=str))
 
-def _is_connection_closed(conn):
-    """
-    Check if a database connection is closed.
-    Works with both psycopg2 connections and Streamlit SQL connections.
-    """
-    if conn is None:
-        return True
-    # Check psycopg2 connection - most reliable method
-    if hasattr(conn, 'closed'):
-        return conn.closed
-    # For Streamlit SQL connections, we can't easily check without a query
-    # Return False (assume open) and let the actual query fail gracefully
-    # The exception handler will catch connection errors
-    return False
-
 @st.cache_resource
 def get_cached_db_connection():
     """
     Get a cached database connection that persists across reruns.
     Uses @st.cache_resource to ensure the connection is reused efficiently.
     """
-    log_debug("map_display.py:14", "get_cached_db_connection entry", {"has_pghost": bool(os.environ.get('PGHOST'))}, "A")
-    if os.environ.get('PGHOST'):
-        conn = get_db_connection()
-        log_debug("map_display.py:17", "get_cached_db_connection created direct connection", {
-            "conn_id": id(conn),
-            "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
-            "conn_type": type(conn).__name__
-        }, "A")
-        return conn
-    else:
-        try:
-            conn = st.connection("postgresql", type="sql")
-            log_debug("map_display.py:21", "get_cached_db_connection created streamlit connection", {
-                "conn_id": id(conn),
-                "conn_type": type(conn).__name__
-            }, "A")
-            return conn
-        except Exception as e:
-            log_debug("map_display.py:24", "get_cached_db_connection streamlit connection failed, using direct", {
-                "error": str(e)
-            }, "A")
-            # If Streamlit connection fails, try direct connection
-            conn = get_db_connection()
-            log_debug("map_display.py:27", "get_cached_db_connection fallback direct connection", {
-                "conn_id": id(conn),
-                "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
-                "conn_type": type(conn).__name__
-            }, "A")
-            return conn
+    log_debug("map_display.py:14", "get_cached_db_connection entry", {}, "A")
+    conn = get_db_connection()
+    log_debug("map_display.py:17", "get_cached_db_connection created connection", {
+        "conn_id": id(conn),
+        "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
+        "conn_type": type(conn).__name__
+    }, "A")
+    return conn
 
 @st.cache_data
 def cached_get_location(city_name):

--- a/scripts/check_config.py
+++ b/scripts/check_config.py
@@ -2,42 +2,22 @@
 Validate that required configuration is present.
 Run this at startup or in CI/CD to catch missing env vars early.
 """
-import os
 import sys
+from services.db import validate_pg_env
+
 
 def check_config():
-    """Check for required configuration (Replit env vars or Streamlit secrets)."""
-    replit_vars = [
-        'PGHOST',
-        'PGPORT',
-        'PGDATABASE',
-        'PGUSER',
-        'PGPASSWORD'
-    ]
-    
-    has_replit = all(os.environ.get(var) for var in replit_vars)
-    
-    if has_replit:
-        print("✅ Replit PostgreSQL configuration found")
+    """Check for required database environment variables."""
+    missing = validate_pg_env()
+
+    if not missing:
+        print("Database configuration found (all PG* env vars set)")
         return True
-    
-    # Check for Streamlit secrets (can't fully validate without importing streamlit)
-    try:
-        import streamlit as st
-        try:
-            secrets = st.secrets["connections"]["postgresql"]
-            required_keys = ['host', 'port', 'database', 'username', 'password']
-            if all(key in secrets for key in required_keys):
-                print("✅ Streamlit secrets configuration found")
-                return True
-        except (KeyError, AttributeError):
-            pass
-    except ImportError:
-        pass
-    
-    print("❌ ERROR: No valid database configuration found")
-    print("   Required: Either Replit PostgreSQL env vars or Streamlit secrets")
+
+    print(f"ERROR: Missing database environment variables: {', '.join(missing)}")
+    print("   Required: PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD")
     return False
+
 
 if __name__ == "__main__":
     success = check_config()

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -4,7 +4,7 @@ Run this after migrations or before deployment to catch schema drift.
 """
 import sys
 import psycopg2
-from services.walkability import get_db_connection
+from services.db import get_db_connection
 
 EXPECTED_COLUMNS = {
     'geoid20': 'character varying',

--- a/services/db.py
+++ b/services/db.py
@@ -1,0 +1,90 @@
+"""
+Framework-agnostic database connection factory.
+
+Reads PostgreSQL credentials from environment variables (PGHOST, PGPORT,
+PGDATABASE, PGUSER, PGPASSWORD). No Streamlit, Flask, or other framework
+imports.
+"""
+import os
+import psycopg2
+
+REQUIRED_PG_VARS = ['PGDATABASE', 'PGHOST', 'PGPASSWORD', 'PGPORT', 'PGUSER']
+
+
+def validate_pg_env():
+    """Return a sorted list of missing PG* environment variable names.
+
+    Returns an empty list when all required vars are present.
+    """
+    return sorted(v for v in REQUIRED_PG_VARS if not os.environ.get(v))
+
+
+def get_pg_env():
+    """Read and validate PG* environment variables.
+
+    Returns:
+        dict with keys: host, port (int), database, user, password.
+
+    Raises:
+        EnvironmentError: if any required PG* vars are missing.
+        ValueError: if PGPORT is not a valid integer.
+    """
+    missing = validate_pg_env()
+    if missing:
+        raise EnvironmentError(
+            f"Missing required database environment variables: {', '.join(missing)}. "
+            "Set PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD."
+        )
+
+    raw_port = os.environ['PGPORT']
+    try:
+        port = int(raw_port)
+    except (ValueError, TypeError):
+        raise ValueError(f"PGPORT must be an integer, got '{raw_port}'")
+
+    return {
+        'host': os.environ['PGHOST'],
+        'port': port,
+        'database': os.environ['PGDATABASE'],
+        'user': os.environ['PGUSER'],
+        'password': os.environ['PGPASSWORD'],
+    }
+
+
+def get_db_connection():
+    """Create a PostgreSQL connection using environment variables.
+
+    Returns:
+        psycopg2 connection object.
+
+    Raises:
+        EnvironmentError: if required env vars are missing.
+        ValueError: if PGPORT is not a valid integer.
+        psycopg2.OperationalError: if the connection attempt fails.
+    """
+    env = get_pg_env()
+    return psycopg2.connect(
+        host=env['host'],
+        port=env['port'],
+        database=env['database'],
+        user=env['user'],
+        password=env['password'],
+    )
+
+
+def is_connection_closed(conn):
+    """Check if a database connection is closed or broken.
+
+    psycopg2 semantics: conn.closed is 0 when open, nonzero when the
+    connection is closed or broken (e.g. server dropped it).  This
+    function also handles None connections, missing ``closed`` attribute
+    (e.g. Streamlit SQL wrappers), and boolean mocks.
+    """
+    if conn is None:
+        return True
+    closed_value = getattr(conn, "closed", 0)
+    if isinstance(closed_value, bool):
+        return closed_value
+    if isinstance(closed_value, int):
+        return closed_value != 0
+    return False

--- a/services/walkability.py
+++ b/services/walkability.py
@@ -42,19 +42,8 @@ def log_debug(location, message, data=None, hypothesis_id=None):
         }
         _DEBUG_LOGGER.info(json.dumps(fallback, default=str))
 
-def _is_connection_closed(conn):
-    """
-    Check if a database connection is closed.
-    Works with psycopg2 connections and safely ignores non-boolean mocks.
-    """
-    if conn is None:
-        return True
-    closed_value = getattr(conn, "closed", 0)
-    if isinstance(closed_value, bool):
-        return closed_value
-    if isinstance(closed_value, int):
-        return closed_value != 0
-    return False
+from services.db import get_db_connection
+from services.db import is_connection_closed as _is_connection_closed
 
 @retry(
     stop=stop_after_attempt(3), 
@@ -112,55 +101,18 @@ def miles_to_degrees(miles, latitude):
     degrees_longitude = miles / (69.0 * math.cos(math.radians(latitude)))
     return degrees_latitude, degrees_longitude
 
-def get_db_connection():
-    """
-    Create a PostgreSQL connection using Replit's environment variables.
-    Falls back to Streamlit secrets if Replit env vars are not available.
-    """
-    try:
-        # Try Replit PostgreSQL environment variables first
-        db_host = os.environ.get('PGHOST')
-        db_port = os.environ.get('PGPORT')
-        db_name = os.environ.get('PGDATABASE')
-        db_user = os.environ.get('PGUSER')
-        db_password = os.environ.get('PGPASSWORD')
-        
-        if all([db_host, db_port, db_name, db_user, db_password]):
-            return psycopg2.connect(
-                host=db_host,
-                port=int(db_port) if isinstance(db_port, str) else db_port,
-                database=db_name,
-                user=db_user,
-                password=db_password
-            )
-    except (TypeError, ValueError, psycopg2.OperationalError) as e:
-        logging.warning(f"Could not connect using Replit env vars: {e}")
-    
-    # Fallback: try to import streamlit and use secrets
-    try:
-        import streamlit as st
-        db_secrets = st.secrets["connections"]["postgresql"]
-        return psycopg2.connect(
-            host=db_secrets["host"],
-            port=db_secrets["port"],
-            database=db_secrets["database"],
-            user=db_secrets["username"],
-            password=db_secrets["password"]
-        )
-    except Exception as e:
-        raise Exception(f"Could not connect to database. Check Replit PostgreSQL env vars or Streamlit secrets. Error: {e}")
-
 def get_walkability_data(location_string, buffer_size, conn=None):
     """
     Fetch walkability data within a given buffer radius around the stated location.
-    
+
     Args:
         location_string: Address, ZIP code, or city name
         buffer_size: Buffer radius in miles
-        conn: Database connection (psycopg2 connection object or Streamlit SQL connection)
-              If None, will attempt to create a connection using Replit env vars or Streamlit secrets.
-              Note: For best performance, pass a cached connection from @st.cache_resource.
-    
+        conn: psycopg2 connection, or None.
+              If None, creates a new connection via get_db_connection() and
+              closes it when done (try/finally). If provided, caller owns
+              the lifecycle — this function will not close it.
+
     Returns:
         GeoDataFrame with walkability data, or None if location not found
     """
@@ -169,12 +121,12 @@ def get_walkability_data(location_string, buffer_size, conn=None):
     if not is_valid:
         logging.error(f"Invalid location input: {error_msg}")
         raise ValueError(f"Invalid location input: {error_msg}")
-    
+
     is_valid, error_msg = validate_buffer_size(buffer_size)
     if not is_valid:
         logging.error(f"Invalid buffer size: {error_msg}")
         raise ValueError(f"Invalid buffer size: {error_msg}")
-    
+
     location = get_location(location_string)
     if not location:
         return None
@@ -182,134 +134,105 @@ def get_walkability_data(location_string, buffer_size, conn=None):
     degrees_latitude, degrees_longitude = miles_to_degrees(buffer_size, latitude)
     buffer_radius_degrees = max(degrees_latitude, degrees_longitude)
 
-    # Handle both Streamlit SQL connection and direct psycopg2 connection
-    if conn and hasattr(conn, 'query'):
-        # Streamlit SQL connection (backward compatibility)
+    log_debug("walkability.py:172", "get_walkability_data entry", {
+        "conn_provided": conn is not None,
+        "conn_id": id(conn) if conn else None,
+        "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
+        "conn_type": type(conn).__name__ if conn else None
+    }, "A")
+    should_close_conn = False
+    if conn is None:
+        conn = get_db_connection()
+        should_close_conn = True
+        log_debug("walkability.py:178", "get_walkability_data created new connection", {
+            "conn_id": id(conn),
+            "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+        }, "A")
+
+    if conn and hasattr(conn, 'closed'):
+        if conn.closed:
+            log_debug("walkability.py:185", "get_walkability_data connection CLOSED before cursor", {
+                "conn_id": id(conn)
+            }, "A")
+        else:
+            log_debug("walkability.py:189", "get_walkability_data connection OPEN before cursor", {
+                "conn_id": id(conn)
+            }, "A")
+
+    try:
         query = """
-            SELECT 
+            SELECT
                 geoid20,
                 d2a_ranked,
-                d2b_ranked, 
-                d3b_ranked, 
+                d2b_ranked,
+                d3b_ranked,
                 d4a_ranked,
-                natwalkind, 
-                geometry
+                natwalkind,
+                ST_AsBinary(geometry) as geometry
             FROM national_walkability_index
             WHERE ST_DWithin(
-                st_setsrid(st_makepoint(:longitude, :latitude), 4326),
+                st_setsrid(st_makepoint(%s, %s), 4326),
                 geometry,
-                :buffer_radius_degrees
+                %s
             );
         """
-        df = conn.query(
-            query,
-            ttl="10m",
-            params={"longitude": longitude, "latitude": latitude, "buffer_radius_degrees": buffer_radius_degrees}
-        )
-        gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkb(df['geometry']))
-    else:
-        # Direct psycopg2 connection (Replit PostgreSQL)
-        # Note: If conn is provided, we use it (assumed to be cached/managed externally)
-        # If None, we create a new one (for backward compatibility)
-        log_debug("walkability.py:172", "get_walkability_data psycopg2 path entry", {
-            "conn_provided": conn is not None,
+
+        log_debug("walkability.py:198", "get_walkability_data about to create cursor", {
+            "conn_id": id(conn),
+            "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+        }, "A")
+
+        # Check connection health before using it
+        if _is_connection_closed(conn):
+            log_debug("walkability.py:203", "get_walkability_data connection closed before cursor creation", {
+                "conn_id": id(conn)
+            }, "A")
+            raise psycopg2.InterfaceError("Connection is closed")
+
+        with conn.cursor() as cursor:
+            log_debug("walkability.py:200", "get_walkability_data cursor created successfully", {
+                "conn_id": id(conn),
+                "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+            }, "A")
+            cursor.execute(query, (longitude, latitude, buffer_radius_degrees))
+            log_debug("walkability.py:203", "get_walkability_data query executed", {
+                "conn_id": id(conn),
+                "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+            }, "A")
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            df = pd.DataFrame(rows, columns=columns)
+            log_debug("walkability.py:207", "get_walkability_data data fetched", {
+                "conn_id": id(conn),
+                "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
+                "row_count": len(rows)
+            }, "A")
+
+        # Convert geometry bytes to GeoSeries
+        # Handle memoryview objects from psycopg2 by converting to bytes
+        geometry_data = df['geometry'].apply(lambda x: bytes(x) if isinstance(x, memoryview) else x)
+        gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkb(geometry_data))
+    except Exception as e:
+        log_debug("walkability.py:212", "get_walkability_data exception during query", {
             "conn_id": id(conn) if conn else None,
             "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
-            "conn_type": type(conn).__name__ if conn else None
+            "error_type": type(e).__name__,
+            "error_message": str(e)
         }, "A")
-        should_close_conn = False
-        if conn is None:
-            conn = get_db_connection()
-            should_close_conn = True
-            log_debug("walkability.py:178", "get_walkability_data created new connection", {
+        raise
+    finally:
+        # Only close if we created the connection ourselves
+        if should_close_conn and conn:
+            log_debug("walkability.py:220", "get_walkability_data closing connection", {
                 "conn_id": id(conn),
-                "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+                "conn_closed_before": conn.closed if hasattr(conn, 'closed') else None
             }, "A")
-        
-        if conn and hasattr(conn, 'closed'):
-            if conn.closed:
-                log_debug("walkability.py:185", "get_walkability_data connection CLOSED before cursor", {
-                    "conn_id": id(conn)
-                }, "A")
-            else:
-                log_debug("walkability.py:189", "get_walkability_data connection OPEN before cursor", {
-                    "conn_id": id(conn)
-                }, "A")
-        
-        try:
-            query = """
-                SELECT 
-                    geoid20,
-                    d2a_ranked,
-                    d2b_ranked, 
-                    d3b_ranked, 
-                    d4a_ranked,
-                    natwalkind, 
-                    ST_AsBinary(geometry) as geometry
-                FROM national_walkability_index
-                WHERE ST_DWithin(
-                    st_setsrid(st_makepoint(%s, %s), 4326),
-                    geometry,
-                    %s
-                );
-            """
-            
-            log_debug("walkability.py:198", "get_walkability_data about to create cursor", {
+            conn.close()
+            log_debug("walkability.py:225", "get_walkability_data connection closed", {
                 "conn_id": id(conn),
-                "conn_closed": conn.closed if hasattr(conn, 'closed') else None
+                "conn_closed_after": conn.closed if hasattr(conn, 'closed') else None
             }, "A")
-            
-            # Check connection health before using it
-            if _is_connection_closed(conn):
-                log_debug("walkability.py:203", "get_walkability_data connection closed before cursor creation", {
-                    "conn_id": id(conn)
-                }, "A")
-                raise psycopg2.InterfaceError("Connection is closed")
-            
-            with conn.cursor() as cursor:
-                log_debug("walkability.py:200", "get_walkability_data cursor created successfully", {
-                    "conn_id": id(conn),
-                    "conn_closed": conn.closed if hasattr(conn, 'closed') else None
-                }, "A")
-                cursor.execute(query, (longitude, latitude, buffer_radius_degrees))
-                log_debug("walkability.py:203", "get_walkability_data query executed", {
-                    "conn_id": id(conn),
-                    "conn_closed": conn.closed if hasattr(conn, 'closed') else None
-                }, "A")
-                columns = [desc[0] for desc in cursor.description]
-                rows = cursor.fetchall()
-                df = pd.DataFrame(rows, columns=columns)
-                log_debug("walkability.py:207", "get_walkability_data data fetched", {
-                    "conn_id": id(conn),
-                    "conn_closed": conn.closed if hasattr(conn, 'closed') else None,
-                    "row_count": len(rows)
-                }, "A")
-            
-            # Convert geometry bytes to GeoSeries
-            # Handle memoryview objects from psycopg2 by converting to bytes
-            geometry_data = df['geometry'].apply(lambda x: bytes(x) if isinstance(x, memoryview) else x)
-            gdf = gpd.GeoDataFrame(df, geometry=gpd.GeoSeries.from_wkb(geometry_data))
-        except Exception as e:
-            log_debug("walkability.py:212", "get_walkability_data exception during query", {
-                "conn_id": id(conn) if conn else None,
-                "conn_closed": conn.closed if conn and hasattr(conn, 'closed') else None,
-                "error_type": type(e).__name__,
-                "error_message": str(e)
-            }, "A")
-            raise
-        finally:
-            # Only close if we created the connection ourselves
-            if should_close_conn and conn:
-                log_debug("walkability.py:220", "get_walkability_data closing connection", {
-                    "conn_id": id(conn),
-                    "conn_closed_before": conn.closed if hasattr(conn, 'closed') else None
-                }, "A")
-                conn.close()
-                log_debug("walkability.py:225", "get_walkability_data connection closed", {
-                    "conn_id": id(conn),
-                    "conn_closed_after": conn.closed if hasattr(conn, 'closed') else None
-                }, "A")
-    
+
     # Ensure numeric columns are properly typed (important for Folium Choropleth)
     # This handles cases where database returns strings or object types
     numeric_columns = ['d2a_ranked', 'd2b_ranked', 'd3b_ranked', 'd4a_ranked', 'natwalkind']

--- a/tests/test_connection_caching.py
+++ b/tests/test_connection_caching.py
@@ -42,12 +42,9 @@ class TestConnectionClosedDetection:
         mock_conn.closed = True
         assert _is_connection_closed(mock_conn) is True
     
-    def test_is_connection_closed_streamlit_connection(self):
-        """Test that Streamlit SQL connection (without closed attr) returns False."""
-        # Streamlit connections don't have 'closed' attribute
-        # We assume they're open and let the query fail gracefully
-        mock_conn = Mock()
-        del mock_conn.closed  # Remove closed attribute if it exists
+    def test_is_connection_closed_missing_attr(self):
+        """Test that connection without 'closed' attribute returns False."""
+        mock_conn = Mock(spec=[])  # no attributes
         assert _is_connection_closed(mock_conn) is False
 
 
@@ -55,60 +52,38 @@ class TestCachedConnection:
     """Test the get_cached_db_connection caching behavior."""
     
     @patch('components.map_display.get_db_connection')
-    @patch('components.map_display.os.environ.get')
-    def test_get_cached_db_connection_creates_connection(self, mock_env_get, mock_get_db):
+    def test_get_cached_db_connection_creates_connection(self, mock_get_db):
         """Test that a new connection is created when cache is empty."""
-        mock_env_get.return_value = 'test_host'  # Simulate PGHOST set
         mock_conn = Mock()
         mock_conn.closed = False
         mock_get_db.return_value = mock_conn
-        
+
         # Clear cache first
         get_cached_db_connection.clear()
-        
+
         conn = get_cached_db_connection()
-        
+
         assert conn == mock_conn
         mock_get_db.assert_called_once()
     
     @patch('components.map_display.get_db_connection')
-    @patch('components.map_display.os.environ.get')
-    def test_get_cached_db_connection_reuses_cached(self, mock_env_get, mock_get_db):
+    def test_get_cached_db_connection_reuses_cached(self, mock_get_db):
         """Test that cached connection is reused on subsequent calls."""
-        mock_env_get.return_value = 'test_host'
         mock_conn = Mock()
         mock_conn.closed = False
         mock_get_db.return_value = mock_conn
-        
+
         # Clear cache first
         get_cached_db_connection.clear()
-        
+
         # First call creates connection
         conn1 = get_cached_db_connection()
         # Second call should reuse cached connection
         conn2 = get_cached_db_connection()
-        
+
         assert conn1 == conn2
         # Should only be called once due to caching
         assert mock_get_db.call_count == 1
-    
-    @patch('components.map_display.st.connection')
-    @patch('components.map_display.os.environ.get')
-    def test_get_cached_db_connection_fallback_to_direct(self, mock_env_get, mock_st_conn):
-        """Test fallback to direct connection when Streamlit connection fails."""
-        mock_env_get.return_value = None  # No PGHOST, try Streamlit connection
-        
-        # Simulate Streamlit connection failure
-        mock_st_conn.side_effect = Exception("Connection failed")
-        
-        mock_direct_conn = Mock()
-        mock_direct_conn.closed = False
-        
-        with patch('components.map_display.get_db_connection', return_value=mock_direct_conn):
-            get_cached_db_connection.clear()
-            conn = get_cached_db_connection()
-            
-            assert conn == mock_direct_conn
 
 
 class TestCachedWalkabilityDataWithClosedConnection:
@@ -241,10 +216,7 @@ class TestWalkabilityDataConnectionCheck:
         """Test that get_walkability_data raises InterfaceError for closed connection."""
         closed_conn = Mock()
         closed_conn.closed = True
-        # Ensure it doesn't have 'query' attribute so it goes to psycopg2 path
-        if hasattr(closed_conn, 'query'):
-            delattr(closed_conn, 'query')
-        
+
         with pytest.raises(psycopg2.InterfaceError) as exc_info:
             get_walkability_data("Knoxville, TN", 1.0, conn=closed_conn)
         
@@ -255,10 +227,7 @@ class TestWalkabilityDataConnectionCheck:
         """Test that get_walkability_data works with open connection."""
         open_conn = Mock()
         open_conn.closed = False
-        # Ensure it doesn't have 'query' attribute so it goes to psycopg2 path
-        if hasattr(open_conn, 'query'):
-            delattr(open_conn, 'query')
-        
+
         mock_cursor = Mock()
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,111 @@
+"""Tests for services.db module."""
+import pytest
+from unittest.mock import patch, Mock
+from services.db import validate_pg_env, get_pg_env, get_db_connection, is_connection_closed
+
+
+PG_ENV = {
+    'PGHOST': 'localhost',
+    'PGPORT': '5432',
+    'PGDATABASE': 'testdb',
+    'PGUSER': 'testuser',
+    'PGPASSWORD': 'testpass',
+}
+
+
+class TestValidatePgEnv:
+
+    def test_all_present(self, monkeypatch):
+        for k, v in PG_ENV.items():
+            monkeypatch.setenv(k, v)
+        assert validate_pg_env() == []
+
+    def test_missing_returns_sorted(self, monkeypatch):
+        monkeypatch.setenv('PGDATABASE', 'db')
+        monkeypatch.setenv('PGPASSWORD', 'pw')
+        monkeypatch.setenv('PGUSER', 'user')
+        monkeypatch.delenv('PGHOST', raising=False)
+        monkeypatch.delenv('PGPORT', raising=False)
+        assert validate_pg_env() == ['PGHOST', 'PGPORT']
+
+
+class TestGetPgEnv:
+
+    def test_raises_when_missing(self, monkeypatch):
+        monkeypatch.delenv('PGHOST', raising=False)
+        monkeypatch.delenv('PGPORT', raising=False)
+        monkeypatch.delenv('PGDATABASE', raising=False)
+        monkeypatch.delenv('PGUSER', raising=False)
+        monkeypatch.delenv('PGPASSWORD', raising=False)
+        with pytest.raises(EnvironmentError, match="PGDATABASE, PGHOST"):
+            get_pg_env()
+
+    def test_bad_port_raises(self, monkeypatch):
+        for k, v in PG_ENV.items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.setenv('PGPORT', 'abc')
+        with pytest.raises(ValueError, match="PGPORT must be an integer, got 'abc'"):
+            get_pg_env()
+
+    def test_returns_dict_with_int_port(self, monkeypatch):
+        for k, v in PG_ENV.items():
+            monkeypatch.setenv(k, v)
+        env = get_pg_env()
+        assert env['port'] == 5432
+        assert isinstance(env['port'], int)
+        assert env['host'] == 'localhost'
+
+
+class TestGetDbConnection:
+
+    @patch('services.db.psycopg2.connect')
+    def test_calls_psycopg2_with_env(self, mock_connect, monkeypatch):
+        for k, v in PG_ENV.items():
+            monkeypatch.setenv(k, v)
+        get_db_connection()
+        mock_connect.assert_called_once_with(
+            host='localhost',
+            port=5432,
+            database='testdb',
+            user='testuser',
+            password='testpass',
+        )
+
+    def test_raises_when_env_missing(self, monkeypatch):
+        monkeypatch.delenv('PGHOST', raising=False)
+        monkeypatch.delenv('PGPORT', raising=False)
+        monkeypatch.delenv('PGDATABASE', raising=False)
+        monkeypatch.delenv('PGUSER', raising=False)
+        monkeypatch.delenv('PGPASSWORD', raising=False)
+        with pytest.raises(EnvironmentError, match="Missing required"):
+            get_db_connection()
+
+
+class TestIsConnectionClosed:
+
+    def test_none_is_closed(self):
+        assert is_connection_closed(None) is True
+
+    def test_closed_zero_is_open(self):
+        conn = Mock()
+        conn.closed = 0
+        assert is_connection_closed(conn) is False
+
+    def test_closed_nonzero_is_closed(self):
+        conn = Mock()
+        conn.closed = 2
+        assert is_connection_closed(conn) is True
+
+    def test_closed_bool_true(self):
+        conn = Mock()
+        conn.closed = True
+        assert is_connection_closed(conn) is True
+
+    def test_closed_bool_false(self):
+        conn = Mock()
+        conn.closed = False
+        assert is_connection_closed(conn) is False
+
+    def test_missing_closed_attr_is_open(self):
+        conn = Mock(spec=[])  # no attributes
+        assert is_connection_closed(conn) is False


### PR DESCRIPTION
Introduced a new db.py module for a framework-agnostic database connection factory, removing Streamlit dependencies. Updated walkability.py to utilize the new connection methods and improved error handling for missing environment variables. Enhanced configuration validation in check_config.py and updated related documentation in README.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production DB connections are created and validated (removing Streamlit secrets fallback), which can break deployments that relied on the old configuration path if env vars aren’t set correctly.
> 
> **Overview**
> Refactors database connectivity to be **env-var only** by introducing `services/db.py` (`validate_pg_env`, `get_pg_env`, `get_db_connection`, `is_connection_closed`) and updating the app and scripts to use it instead of Streamlit-specific connection/secrets logic.
> 
> `services/walkability.py` now relies on psycopg2 connections exclusively, manages optional connection ownership (create/close when `conn=None`), and performs a consistent pre-query closed-connection check; `components/map_display.py` correspondingly simplifies cached connection creation and imports the shared connection-closed helper. Config/docs are updated to require `PG*` env vars, and tests are extended with new coverage for the `services/db.py` helpers and revised connection-caching expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80326db200ab881810df4ebae8674a24ebbab479. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->