### PR TITLE
Enhance map visualization and data handling

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(git rm:*)",
       "Bash(git mv:*)",
       "Bash(.venv/Scripts/python.exe -m pytest tests/test_walkability.py -v)",
-      "Bash(.venv/Scripts/python.exe -m pytest tests/test_walkability.py -q)"
+      "Bash(.venv/Scripts/python.exe -m pytest tests/test_walkability.py -q)",
+      "Bash(.venv/Scripts/python.exe -m pytest:*)"
     ]
   }
 }

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -41,6 +41,12 @@ class Metrics(BaseModel):
     transit_viability: float | None
 
 
+class BlockGroupFeature(BaseModel):
+    geoid20: str | None
+    natwalkind: float | None
+    geometry: dict[str, Any]  # GeoJSON geometry object (type + coordinates)
+
+
 class UpgradeCandidate(BaseModel):
     geoid20: str | None
     natwalkind: float | None
@@ -80,6 +86,7 @@ class NwiSummaryResponse(BaseModel):
     metrics: Metrics
     upgrade_potential: UpgradePotential
     walkable_island: WalkableIsland
+    block_groups: list[BlockGroupFeature] = Field(default_factory=list)
 
 
 class ErrorResponse(BaseModel):

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -493,6 +493,30 @@
   margin-top: 0.5rem;
 }
 
+.map-view__legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  color: #374151;
+}
+
+.map-view__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.map-view__legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  flex-shrink: 0;
+}
+
 .explore__nearby table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -25,6 +25,11 @@ L.Marker.prototype.options.icon = DefaultIcon;
 const NWI_TIER_HIGH = 3;
 const NWI_TIER_LOW  = 1;
 
+// Fill color for block groups where natwalkind or the area mean is unavailable.
+// Must be visually distinct from every NWI_TIERS color so users are never
+// misled into thinking an unknown block group is "Near avg".
+const NWI_NO_DATA_COLOR = "#9ca3af";  // neutral gray
+
 // Single source of truth for colors and labels. nwiDeltaColor and the legend
 // both iterate this array so they can never fall out of sync.
 const NWI_TIERS: Array<{ min: number; color: string; label: string }> = [
@@ -126,10 +131,10 @@ export function MapView({ lat, lon, radiusMiles, label, blockGroups, nwiMean, fi
     const layer = L.geoJSON(geojsonData, {
       style: (feature) => {
         const nwi = (feature?.properties?.natwalkind as number | null) ?? null;
-        const delta = nwi != null && nwiMean != null ? nwi - nwiMean : 0;
+        const hasData = nwi != null && nwiMean != null;
         return {
-          fillColor: nwiDeltaColor(delta),
-          fillOpacity: 0.45,
+          fillColor: hasData ? nwiDeltaColor(nwi - nwiMean) : NWI_NO_DATA_COLOR,
+          fillOpacity: hasData ? 0.45 : 0.3,  // lower opacity flags missing data
           color: "#444",
           weight: 0.8,
         };
@@ -170,6 +175,10 @@ export function MapView({ lat, lon, radiusMiles, label, blockGroups, nwiMean, fi
               {tier.label}
             </span>
           ))}
+          <span className="map-view__legend-item">
+            <span className="map-view__legend-swatch" style={{ background: NWI_NO_DATA_COLOR }} />
+            No data
+          </span>
         </div>
       )}
       <p className="map-view__caption">

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,10 +1,12 @@
 /**
- * Leaflet map centered on origin; no geometry tiles yet (evidence layer in Phase 1).
+ * Leaflet map centered on origin with a choropleth layer of block groups
+ * colored by walkability relative to the area mean NWI.
  */
 
 import { useEffect, useRef } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import type { BlockGroupFeature } from "../types/api";
 
 // Fix default marker icon with Vite/bundlers (images path is not available).
 const DefaultIcon = L.icon({
@@ -16,19 +18,44 @@ const DefaultIcon = L.icon({
 });
 L.Marker.prototype.options.icon = DefaultIcon;
 
+// NWI delta thresholds for the five-tier color scale.
+// NWI ranges 1–20. ±1 point captures the zone of statistical noise around
+// the local mean; ±3 points marks a tier of practical significance (roughly
+// one population std-dev in typical US metro census block groups).
+const NWI_TIER_HIGH = 3;
+const NWI_TIER_LOW  = 1;
+
+// Single source of truth for colors and labels. nwiDeltaColor and the legend
+// both iterate this array so they can never fall out of sync.
+const NWI_TIERS: Array<{ min: number; color: string; label: string }> = [
+  { min:  NWI_TIER_HIGH,  color: "#1a7d3e", label: `Well above avg (≥+${NWI_TIER_HIGH})` },
+  { min:  NWI_TIER_LOW,   color: "#5cb85c", label: `Above avg (+${NWI_TIER_LOW} to +${NWI_TIER_HIGH})` },
+  { min: -NWI_TIER_LOW,   color: "#f0ad4e", label: `Near avg (±${NWI_TIER_LOW})` },
+  { min: -NWI_TIER_HIGH,  color: "#e8622a", label: `Below avg (−${NWI_TIER_LOW} to −${NWI_TIER_HIGH})` },
+  { min: -Infinity,        color: "#c0392b", label: `Well below avg (<−${NWI_TIER_HIGH})` },
+];
+
+/** Color a block group by its NWI delta relative to the area mean. */
+function nwiDeltaColor(delta: number): string {
+  return NWI_TIERS.find((t) => delta >= t.min)?.color ?? "#c0392b";
+}
+
 interface MapViewProps {
   lat: number;
   lon: number;
   radiusMiles: number;
   label?: string | null;
+  blockGroups?: BlockGroupFeature[] | null;
+  nwiMean?: number | null;
   /** When true, container height is controlled by parent (e.g. split layout). */
   fillHeight?: boolean;
 }
 
-export function MapView({ lat, lon, radiusMiles, label, fillHeight }: MapViewProps) {
+export function MapView({ lat, lon, radiusMiles, label, blockGroups, nwiMean, fillHeight }: MapViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
+  const blockGroupsLayerRef = useRef<L.GeoJSON | null>(null);
 
   // Create or update map when lat/lon/label change.
   useEffect(() => {
@@ -43,6 +70,7 @@ export function MapView({ lat, lon, radiusMiles, label, fillHeight }: MapViewPro
       existingMap.remove();
       mapRef.current = null;
       markerRef.current = null;
+      blockGroupsLayerRef.current = null;
     }
 
     if (mapRef.current) {
@@ -74,17 +102,58 @@ export function MapView({ lat, lon, radiusMiles, label, fillHeight }: MapViewPro
     // No cleanup here: reuse map on prop changes (update path above). Unmount cleanup is in the effect below.
   }, [lat, lon, label]);
 
+  // Add or replace the block group choropleth layer when data changes.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    // Remove existing choropleth layer.
+    if (blockGroupsLayerRef.current) {
+      blockGroupsLayerRef.current.remove();
+      blockGroupsLayerRef.current = null;
+    }
+    if (!blockGroups || blockGroups.length === 0) return;
+
+    const geojsonData = {
+      type: "FeatureCollection" as const,
+      features: blockGroups.map((bg) => ({
+        type: "Feature" as const,
+        properties: { geoid20: bg.geoid20, natwalkind: bg.natwalkind },
+        geometry: bg.geometry,
+      })),
+    };
+
+    const layer = L.geoJSON(geojsonData, {
+      style: (feature) => {
+        const nwi = (feature?.properties?.natwalkind as number | null) ?? null;
+        const delta = nwi != null && nwiMean != null ? nwi - nwiMean : 0;
+        return {
+          fillColor: nwiDeltaColor(delta),
+          fillOpacity: 0.45,
+          color: "#444",
+          weight: 0.8,
+        };
+      },
+    });
+
+    layer.addTo(map);
+    layer.bringToBack();  // Z-order: tiles (bottom) → choropleth → marker (top).
+    blockGroupsLayerRef.current = layer;
+  }, [blockGroups, nwiMean]);
+
   // Teardown map on unmount so the Leaflet instance and listeners are always removed.
-  // (The effect above does not return a cleanup when it creates or updates the map.)
   useEffect(() => {
     return () => {
       if (mapRef.current) {
         mapRef.current.remove();
         mapRef.current = null;
         markerRef.current = null;
+        blockGroupsLayerRef.current = null;
       }
     };
   }, []);
+
+  const showLegend = blockGroups && blockGroups.length > 0;
 
   return (
     <div className="map-view">
@@ -93,6 +162,16 @@ export function MapView({ lat, lon, radiusMiles, label, fillHeight }: MapViewPro
         className="map-view__container"
         style={fillHeight ? undefined : { height: "360px" }}
       />
+      {showLegend && (
+        <div className="map-view__legend">
+          {NWI_TIERS.map((tier) => (
+            <span key={tier.color} className="map-view__legend-item">
+              <span className="map-view__legend-swatch" style={{ background: tier.color }} />
+              {tier.label}
+            </span>
+          ))}
+        </div>
+      )}
       <p className="map-view__caption">
         Center: {lat.toFixed(4)}, {lon.toFixed(4)} · Radius: {radiusMiles} mi
       </p>

--- a/frontend/src/pages/Explore.tsx
+++ b/frontend/src/pages/Explore.tsx
@@ -148,6 +148,8 @@ export function Explore() {
                 lon={summary.origin.lon}
                 radiusMiles={summary.selected_radius_miles}
                 label={summary.origin.label ?? undefined}
+                blockGroups={summary.block_groups}
+                nwiMean={summary.nwi.mean}  {/* mean of selected radius — colors are relative to searched area */}
                 fillHeight
               />
             </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -31,6 +31,12 @@ export interface Metrics {
   transit_viability: number | null;
 }
 
+export interface BlockGroupFeature {
+  geoid20: string | null;
+  natwalkind: number | null;
+  geometry: GeoJSON.Geometry;
+}
+
 export interface UpgradeCandidate {
   geoid20: string | null;
   natwalkind: number | null;
@@ -64,6 +70,7 @@ export interface NwiSummaryResponse {
   metrics: Metrics;
   upgrade_potential: UpgradePotential;
   walkable_island: WalkableIsland;
+  block_groups: BlockGroupFeature[];
 }
 
 export interface GeocodeResponse {

--- a/services/profile_summary.py
+++ b/services/profile_summary.py
@@ -1,14 +1,21 @@
 """Framework-agnostic profile summary service for API-first migration."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pandas as pd
+import shapely.geometry as sg
 
 from services.metrics import compute_full_profile
 from services.walkability import get_location, query_walkability_by_coords, validate_buffer_size
 
-SCHEMA_VERSION = "2026-02-14"
+_log = logging.getLogger(__name__)
+
+# Bumped when block_groups was added to the response payload.
+# The API is always forward-compatible (new fields have defaults), so this
+# string is documentary only — the frontend does not gate on it.
+SCHEMA_VERSION = "2026-02-19"
 
 
 def _validate_coordinates(lat: float, lon: float) -> tuple[float, float]:
@@ -63,6 +70,19 @@ def _safe_float(value: Any) -> float | None:
     if pd.isna(value):
         return None
     return value
+
+
+def _geom_to_geojson(geom) -> dict | None:
+    """Convert a Shapely geometry to a GeoJSON geometry dict, or None on failure."""
+    if geom is None:
+        return None
+    try:
+        if hasattr(geom, "is_empty") and geom.is_empty:
+            return None
+        return sg.mapping(geom)
+    except Exception as exc:
+        _log.warning("_geom_to_geojson: failed to convert geometry (%s): %s", type(geom).__name__, exc)
+        return None
 
 
 def _mean_column(gdf, column: str) -> float | None:
@@ -121,6 +141,23 @@ def _build_response(
     origin_label: str | None,
 ) -> dict[str, Any]:
     """Build canonical summary response payload."""
+    # Serialize selected block group geometries for choropleth map rendering.
+    # Iterate via zip over pre-extracted column lists to avoid per-row Series
+    # allocation from iterrows().
+    block_groups = []
+    if selected_gdf is not None and "geometry" in selected_gdf.columns:
+        geoid_vals = selected_gdf["geoid20"].tolist() if "geoid20" in selected_gdf.columns else [None] * len(selected_gdf)
+        nwi_vals = selected_gdf["natwalkind"].tolist() if "natwalkind" in selected_gdf.columns else [None] * len(selected_gdf)
+        for geoid20, natwalkind, geom in zip(geoid_vals, nwi_vals, selected_gdf["geometry"], strict=True):
+            geom_json = _geom_to_geojson(geom)
+            if geom_json is None:
+                continue
+            block_groups.append({
+                "geoid20": str(geoid20) if pd.notna(geoid20) else None,
+                "natwalkind": _safe_float(natwalkind),
+                "geometry": geom_json,
+            })
+
     return {
         "schema_version": SCHEMA_VERSION,
         "origin": {
@@ -132,7 +169,9 @@ def _build_response(
         "search_radius_miles": float(search_radius_miles),
         "min_delta": float(min_delta),
         "counts": {
-            "selected_block_groups": int(len(selected_gdf)) if selected_gdf is not None else 0,
+            # Use len(block_groups) so the count matches the array length exactly,
+            # even if a row was dropped because its geometry failed to serialize.
+            "selected_block_groups": len(block_groups),
             "context_block_groups": int(len(context_gdf)) if context_gdf is not None else 0,
         },
         "nwi": _build_nwi_stats(selected_gdf),
@@ -149,6 +188,7 @@ def _build_response(
         },
         "upgrade_potential": profile.get("upgrade_potential"),
         "walkable_island": profile.get("walkable_island"),
+        "block_groups": block_groups,
     }
 
 

--- a/tests/test_profile_summary.py
+++ b/tests/test_profile_summary.py
@@ -42,7 +42,7 @@ class TestBuildSummaryFromCoords:
             )
 
         mock_query.assert_called_once_with(-83.92, 35.96, 2.0, conn=None)
-        assert result["schema_version"] == "2026-02-14"
+        assert result["schema_version"] == "2026-02-19"
         assert result["origin"]["lat"] == pytest.approx(35.96)
         assert result["origin"]["lon"] == pytest.approx(-83.92)
         assert result["origin"]["label"] is None
@@ -66,6 +66,16 @@ class TestBuildSummaryFromCoords:
         assert result["upgrade_potential"]["found"] is True
         assert len(result["upgrade_potential"]["candidates"]) == 1
         assert result["upgrade_potential"]["candidates"][0]["geoid20"] == "C"
+
+        # block_groups: 2 block groups fall within selected_radius_miles=1.0 (dist 0.2, 0.8).
+        assert "block_groups" in result
+        assert len(result["block_groups"]) == 2
+        bg0 = result["block_groups"][0]
+        assert bg0["geoid20"] == "A"
+        assert bg0["natwalkind"] == pytest.approx(10.0)
+        assert isinstance(bg0["geometry"], dict)
+        assert "type" in bg0["geometry"]
+        assert "coordinates" in bg0["geometry"]
 
     def test_defaults_search_radius_to_selected_radius(self):
         full_gdf = _sample_gdf(include_dist=True)
@@ -95,6 +105,52 @@ class TestBuildSummaryFromCoords:
 
         assert result["counts"]["selected_block_groups"] == 3
         assert result["counts"]["context_block_groups"] == 3
+
+    def test_block_groups_all_geometries_serialize(self):
+        """All block groups within the search radius get valid GeoJSON geometry dicts."""
+        full_gdf = _sample_gdf(include_dist=True)
+        with patch("services.profile_summary.query_walkability_by_coords", return_value=full_gdf):
+            result = build_summary_from_coords(
+                lat=35.96,
+                lon=-83.92,
+                selected_radius_miles=2.0,
+                search_radius_miles=2.0,
+                min_delta=2.0,
+            )
+        assert len(result["block_groups"]) == 3
+        for bg in result["block_groups"]:
+            assert isinstance(bg["geometry"], dict)
+            assert "type" in bg["geometry"]
+            assert "coordinates" in bg["geometry"]
+
+    def test_block_groups_skips_none_geometry(self):
+        """Rows with None geometry are excluded from block_groups rather than raising."""
+        gdf = gpd.GeoDataFrame(
+            {
+                "geoid20": ["X", "Y"],
+                "natwalkind": [10.0, 14.0],
+                "d2a_ranked": [9.0, 11.0],
+                "d2b_ranked": [8.0, 10.0],
+                "d3b_ranked": [7.0, 9.0],
+                "d4a_ranked": [5.0, 15.0],
+                "geometry": [None, Point(-83.92, 35.96).buffer(0.01)],
+                "dist_miles": [0.2, 0.8],
+            },
+            crs="EPSG:4326",
+        )
+        with patch("services.profile_summary.query_walkability_by_coords", return_value=gdf):
+            result = build_summary_from_coords(
+                lat=35.96,
+                lon=-83.92,
+                selected_radius_miles=2.0,
+                search_radius_miles=2.0,
+                min_delta=2.0,
+            )
+        assert len(result["block_groups"]) == 1
+        assert result["block_groups"][0]["geoid20"] == "Y"
+        # counts.selected_block_groups tracks serialized geometry count, so it
+        # matches len(block_groups) even when rows are dropped for None geometry.
+        assert result["counts"]["selected_block_groups"] == 1
 
     @pytest.mark.parametrize(
         ("kwargs", "message"),


### PR DESCRIPTION
Added BlockGroupFeature model for block group data, updated API response to include block groups, and implemented choropleth layer in MapView component. Enhanced CSS for map legend display and adjusted tests to validate new block group functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the API response shape and adds geometry serialization/rendering, which could impact payload size/performance and map behavior if geometries are malformed or large.
> 
> **Overview**
> Adds `block_groups` (GeoJSON geometry + `geoid20`/`natwalkind`) to the `NwiSummaryResponse` contract and updates the summary service to serialize selected-radius geometries, skipping invalid/empty shapes and making `counts.selected_block_groups` reflect the serialized features (schema version bumped to `2026-02-19`).
> 
> Updates the Explore map UI to render a Leaflet choropleth layer colored by each block group’s NWI delta vs the area mean, with a corresponding legend and “No data” styling; frontend API types and tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30c01eb89fa255ba4e3a30534af6bb458285ed24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->