### PR TITLE
Refactor geocode error messages for clarity and add unit tests for MapView and parameter handling

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -97,6 +97,7 @@ class ErrorResponse(BaseModel):
     - invalid_request: summary params invalid or business-rule failure (e.g. empty query).
     - validation_error: request body/query validation failed (e.g. 422).
     - internal_error: unhandled server error (generic 500).
+    - service_unavailable: database temporarily unavailable (503).
 
     Unhandled HTTPExceptions are serialized with code="http_<status>" (e.g. http_404).
     Frontend maps http_404 and http_422 to the same copy as location_not_found and validation_error.

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -85,7 +85,7 @@ describe("client", () => {
     vi.stubGlobal("fetch", mockFetch);
 
     await expect(geocode("nowhere")).rejects.toThrow(
-      "Location not found. Try a city name or ZIP code."
+      "Location not found. Check your address and try again."
     );
   });
 
@@ -96,7 +96,7 @@ describe("client", () => {
     vi.stubGlobal("fetch", mockFetch);
 
     await expect(geocode("x")).rejects.toThrow(
-      "Location not found. Try a city name or ZIP code."
+      "Location not found. Check your address and try again."
     );
   });
 

--- a/frontend/src/components/MapView.test.tsx
+++ b/frontend/src/components/MapView.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MapView } from "./MapView";
+import type { BlockGroupFeature } from "../types/api";
+
+// Mock Leaflet since it requires DOM and we're testing component logic
+vi.mock("leaflet", () => {
+  const mockMap = {
+    setView: vi.fn(),
+    getZoom: vi.fn(() => 13),
+    getContainer: vi.fn(() => document.createElement("div")),
+    remove: vi.fn(),
+  };
+  const mockMarker = {
+    setLatLng: vi.fn(),
+    bindTooltip: vi.fn(),
+    unbindTooltip: vi.fn(),
+    getTooltip: vi.fn(() => null),
+    addTo: vi.fn(() => mockMarker),
+  };
+  const mockLayer = {
+    addTo: vi.fn(() => mockLayer),
+    remove: vi.fn(),
+    bringToBack: vi.fn(),
+  };
+  const mockGeoJSON = vi.fn(() => mockLayer);
+  const mockTileLayer = vi.fn(() => ({ addTo: vi.fn() }));
+  
+  // Mock Marker class with prototype that can be modified
+  const MockMarker = vi.fn(() => mockMarker);
+  MockMarker.prototype = {
+    options: { icon: null },
+    setLatLng: vi.fn(),
+    bindTooltip: vi.fn(),
+    unbindTooltip: vi.fn(),
+    getTooltip: vi.fn(() => null),
+    addTo: vi.fn(() => mockMarker),
+  };
+  // Make prototype accessible
+  Object.defineProperty(MockMarker, "prototype", {
+    value: MockMarker.prototype,
+    writable: true,
+  });
+
+  const leafletMock = {
+    map: vi.fn(() => mockMap),
+    tileLayer: mockTileLayer,
+    marker: vi.fn(() => mockMarker), // lowercase 'marker' function
+    Marker: MockMarker, // uppercase 'Marker' class
+    geoJSON: mockGeoJSON,
+    icon: vi.fn(),
+  };
+
+  return {
+    default: leafletMock,
+  };
+});
+
+describe("MapView", () => {
+  beforeEach(() => {
+    // Create a container div for the map
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    lat: 42.36,
+    lon: -71.06,
+    radiusMiles: 1.0,
+  };
+
+  it("renders map container", () => {
+    const { container } = render(<MapView {...defaultProps} />);
+    expect(container.querySelector(".map-view__container")).toBeInTheDocument();
+  });
+
+  it("displays caption with coordinates and radius", () => {
+    render(<MapView {...defaultProps} />);
+    expect(screen.getByText(/42\.3600.*-71\.0600/)).toBeInTheDocument();
+    expect(screen.getByText(/1 mi/)).toBeInTheDocument();
+  });
+
+  it("shows legend when block groups are provided", () => {
+    const blockGroups: BlockGroupFeature[] = [
+      {
+        geoid20: "123",
+        natwalkind: 12.0,
+        geometry: { type: "Polygon", coordinates: [[[-71, 42], [-71, 43], [-70, 43], [-70, 42], [-71, 42]]] },
+      },
+    ];
+    render(<MapView {...defaultProps} blockGroups={blockGroups} nwiMean={10.0} />);
+    expect(screen.getByText(/Well above avg/)).toBeInTheDocument();
+    expect(screen.getByText(/No data/)).toBeInTheDocument();
+  });
+
+  it("does not show legend when no block groups", () => {
+    render(<MapView {...defaultProps} blockGroups={[]} />);
+    expect(screen.queryByText(/Well above avg/)).not.toBeInTheDocument();
+  });
+
+  it("does not show legend when blockGroups is null", () => {
+    render(<MapView {...defaultProps} blockGroups={null} />);
+    expect(screen.queryByText(/Well above avg/)).not.toBeInTheDocument();
+  });
+
+  it("handles label prop", () => {
+    render(<MapView {...defaultProps} label="Cambridge, MA" />);
+    // Label is handled by Leaflet marker tooltip, which is mocked
+    // But we can verify the component accepts the prop without error
+    expect(screen.getByText(/42\.3600/)).toBeInTheDocument();
+  });
+
+  it("handles null label", () => {
+    render(<MapView {...defaultProps} label={null} />);
+    expect(screen.getByText(/42\.3600/)).toBeInTheDocument();
+  });
+
+  it("handles empty label", () => {
+    render(<MapView {...defaultProps} label="" />);
+    expect(screen.getByText(/42\.3600/)).toBeInTheDocument();
+  });
+
+  it("handles missing nwiMean", () => {
+    const blockGroups: BlockGroupFeature[] = [
+      {
+        geoid20: "123",
+        natwalkind: 12.0,
+        geometry: { type: "Polygon", coordinates: [[[-71, 42], [-71, 43], [-70, 43], [-70, 42], [-71, 42]]] },
+      },
+    ];
+    render(<MapView {...defaultProps} blockGroups={blockGroups} nwiMean={null} />);
+    // Should render but use "No data" color since nwiMean is null
+    expect(screen.getByText(/No data/)).toBeInTheDocument();
+  });
+
+  it("handles block groups with null natwalkind", () => {
+    const blockGroups: BlockGroupFeature[] = [
+      {
+        geoid20: "123",
+        natwalkind: null,
+        geometry: { type: "Polygon", coordinates: [[[-71, 42], [-71, 43], [-70, 43], [-70, 42], [-71, 42]]] },
+      },
+    ];
+    render(<MapView {...defaultProps} blockGroups={blockGroups} nwiMean={10.0} />);
+    // Should render with "No data" color
+    expect(screen.getByText(/No data/)).toBeInTheDocument();
+  });
+
+  it("formats radius correctly in caption", () => {
+    render(<MapView {...defaultProps} radiusMiles={2.5} />);
+    expect(screen.getByText(/2\.5 mi/)).toBeInTheDocument();
+  });
+
+  it("handles fillHeight prop", () => {
+    const { container } = render(<MapView {...defaultProps} fillHeight={true} />);
+    const mapContainer = container.querySelector(".map-view__container");
+    expect(mapContainer).toBeInTheDocument();
+    // fillHeight affects inline styles, which are hard to test without rendering
+    // But we can verify the component accepts the prop
+  });
+});

--- a/frontend/src/lib/compareParams.test.ts
+++ b/frontend/src/lib/compareParams.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPARE_PARAMS,
+  parseCompareParams,
+  buildCompareSearchParams,
+  canFetchCompare,
+  type CompareParams,
+} from "./compareParams";
+
+describe("compareParams", () => {
+  describe("COMPARE_PARAMS", () => {
+    it("exports RADIUS_DEFAULTS", () => {
+      expect(COMPARE_PARAMS.DEFAULT_RADIUS).toBe(0.5);
+      expect(COMPARE_PARAMS.MIN_RADIUS).toBe(0.1);
+      expect(COMPARE_PARAMS.MAX_RADIUS).toBe(3);
+    });
+  });
+
+  describe("parseCompareParams", () => {
+    it("parses valid params from URLSearchParams", () => {
+      const sp = new URLSearchParams("a=Cambridge%2C+MA&b=Boston&radius=1.0");
+      const result = parseCompareParams(sp);
+      expect(result.params).toEqual({ a: "Cambridge, MA", b: "Boston", radius: 1.0 });
+      expect(result.validationError).toBeNull();
+    });
+
+    it("returns empty strings when a or b are missing", () => {
+      const sp = new URLSearchParams("a=Cambridge&radius=0.5");
+      const result = parseCompareParams(sp);
+      expect(result.params.a).toBe("Cambridge");
+      expect(result.params.b).toBe("");
+      expect(result.params.radius).toBe(0.5);
+    });
+
+    it("uses DEFAULT_RADIUS when radius is missing", () => {
+      const sp = new URLSearchParams("a=Cambridge&b=Boston");
+      const result = parseCompareParams(sp);
+      expect(result.params.radius).toBe(COMPARE_PARAMS.DEFAULT_RADIUS);
+    });
+
+    it("passes through radius validation errors", () => {
+      const sp = new URLSearchParams("a=Cambridge&b=Boston&radius=invalid");
+      const result = parseCompareParams(sp);
+      expect(result.params.a).toBe("Cambridge");
+      expect(result.params.b).toBe("Boston");
+      expect(result.params.radius).toBe(COMPARE_PARAMS.DEFAULT_RADIUS);
+      expect(result.validationError).toBe("Radius must be a number.");
+    });
+
+    it("clamps radius to valid range", () => {
+      const sp = new URLSearchParams("a=Cambridge&b=Boston&radius=10.0");
+      const result = parseCompareParams(sp);
+      expect(result.params.radius).toBe(COMPARE_PARAMS.MAX_RADIUS);
+    });
+
+    it("handles empty search params", () => {
+      const sp = new URLSearchParams();
+      const result = parseCompareParams(sp);
+      expect(result.params.a).toBe("");
+      expect(result.params.b).toBe("");
+      expect(result.params.radius).toBe(COMPARE_PARAMS.DEFAULT_RADIUS);
+    });
+  });
+
+  describe("buildCompareSearchParams", () => {
+    it("builds URLSearchParams from valid params", () => {
+      const params: CompareParams = { a: "Cambridge, MA", b: "Boston", radius: 1.0 };
+      const sp = buildCompareSearchParams(params);
+      expect(sp.get("a")).toBe("Cambridge, MA");
+      expect(sp.get("b")).toBe("Boston");
+      expect(sp.get("radius")).toBe("1");
+    });
+
+    it("omits a when empty", () => {
+      const params: CompareParams = { a: "", b: "Boston", radius: 0.5 };
+      const sp = buildCompareSearchParams(params);
+      expect(sp.has("a")).toBe(false);
+      expect(sp.get("b")).toBe("Boston");
+    });
+
+    it("omits b when empty", () => {
+      const params: CompareParams = { a: "Cambridge", b: "", radius: 0.5 };
+      const sp = buildCompareSearchParams(params);
+      expect(sp.get("a")).toBe("Cambridge");
+      expect(sp.has("b")).toBe(false);
+    });
+
+    it("always includes radius", () => {
+      const params: CompareParams = { a: "Cambridge", b: "Boston", radius: 2.5 };
+      const sp = buildCompareSearchParams(params);
+      expect(sp.get("radius")).toBe("2.5");
+    });
+
+    it("round-trips with parseCompareParams", () => {
+      const original: CompareParams = { a: "Cambridge, MA", b: "Boston, MA", radius: 1.5 };
+      const sp = buildCompareSearchParams(original);
+      const parsed = parseCompareParams(sp);
+      expect(parsed.params.a).toBe(original.a);
+      expect(parsed.params.b).toBe(original.b);
+      expect(parsed.params.radius).toBe(original.radius);
+    });
+  });
+
+  describe("canFetchCompare", () => {
+    it("returns true when both a and b have content", () => {
+      expect(canFetchCompare({ a: "Cambridge", b: "Boston", radius: 0.5 })).toBe(true);
+      expect(canFetchCompare({ a: "Cambridge, MA", b: "Boston, MA", radius: 1.0 })).toBe(true);
+    });
+
+    it("returns false when a is empty", () => {
+      expect(canFetchCompare({ a: "", b: "Boston", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns false when b is empty", () => {
+      expect(canFetchCompare({ a: "Cambridge", b: "", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns false when both are empty", () => {
+      expect(canFetchCompare({ a: "", b: "", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns false when a is whitespace only", () => {
+      expect(canFetchCompare({ a: "   ", b: "Boston", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns false when b is whitespace only", () => {
+      expect(canFetchCompare({ a: "Cambridge", b: "\t\n", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns true when both have content after trim", () => {
+      expect(canFetchCompare({ a: "  Cambridge  ", b: "  Boston  ", radius: 0.5 })).toBe(true);
+    });
+  });
+});

--- a/frontend/src/lib/exploreParams.test.ts
+++ b/frontend/src/lib/exploreParams.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXPLORE_PARAMS,
+  parseExploreParams,
+  buildExploreSearchParams,
+  canFetch,
+  type ExploreParams,
+} from "./exploreParams";
+
+describe("exploreParams", () => {
+  describe("EXPLORE_PARAMS", () => {
+    it("exports RADIUS_DEFAULTS", () => {
+      expect(EXPLORE_PARAMS.DEFAULT_RADIUS).toBe(0.5);
+      expect(EXPLORE_PARAMS.MIN_RADIUS).toBe(0.1);
+      expect(EXPLORE_PARAMS.MAX_RADIUS).toBe(3);
+    });
+  });
+
+  describe("parseExploreParams", () => {
+    it("parses valid params from URLSearchParams", () => {
+      const sp = new URLSearchParams("q=Cambridge%2C+MA&radius=1.0");
+      const result = parseExploreParams(sp);
+      expect(result.params).toEqual({ q: "Cambridge, MA", radius: 1.0 });
+      expect(result.validationError).toBeNull();
+    });
+
+    it("returns empty q when missing", () => {
+      const sp = new URLSearchParams("radius=0.5");
+      const result = parseExploreParams(sp);
+      expect(result.params.q).toBe("");
+      expect(result.params.radius).toBe(0.5);
+    });
+
+    it("uses DEFAULT_RADIUS when radius is missing", () => {
+      const sp = new URLSearchParams("q=Boston");
+      const result = parseExploreParams(sp);
+      expect(result.params.radius).toBe(EXPLORE_PARAMS.DEFAULT_RADIUS);
+    });
+
+    it("passes through radius validation errors", () => {
+      const sp = new URLSearchParams("q=Boston&radius=not-a-number");
+      const result = parseExploreParams(sp);
+      expect(result.params.q).toBe("Boston");
+      expect(result.params.radius).toBe(EXPLORE_PARAMS.DEFAULT_RADIUS);
+      expect(result.validationError).toBe("Radius must be a number.");
+    });
+
+    it("clamps radius to valid range", () => {
+      const sp = new URLSearchParams("q=Boston&radius=5.0");
+      const result = parseExploreParams(sp);
+      expect(result.params.radius).toBe(EXPLORE_PARAMS.MAX_RADIUS);
+    });
+
+    it("handles empty search params", () => {
+      const sp = new URLSearchParams();
+      const result = parseExploreParams(sp);
+      expect(result.params.q).toBe("");
+      expect(result.params.radius).toBe(EXPLORE_PARAMS.DEFAULT_RADIUS);
+    });
+
+    it("preserves query string with special characters", () => {
+      const sp = new URLSearchParams("q=123%20Main%20St%2C%20Boston&radius=1.0");
+      const result = parseExploreParams(sp);
+      expect(result.params.q).toBe("123 Main St, Boston");
+    });
+  });
+
+  describe("buildExploreSearchParams", () => {
+    it("builds URLSearchParams from valid params", () => {
+      const params: ExploreParams = { q: "Cambridge, MA", radius: 1.0 };
+      const sp = buildExploreSearchParams(params);
+      expect(sp.get("q")).toBe("Cambridge, MA");
+      expect(sp.get("radius")).toBe("1");
+    });
+
+    it("omits q when empty", () => {
+      const params: ExploreParams = { q: "", radius: 0.5 };
+      const sp = buildExploreSearchParams(params);
+      expect(sp.has("q")).toBe(false);
+      expect(sp.get("radius")).toBe("0.5");
+    });
+
+    it("always includes radius", () => {
+      const params: ExploreParams = { q: "Boston", radius: 2.5 };
+      const sp = buildExploreSearchParams(params);
+      expect(sp.get("radius")).toBe("2.5");
+    });
+
+    it("round-trips with parseExploreParams", () => {
+      const original: ExploreParams = { q: "Cambridge, MA", radius: 1.5 };
+      const sp = buildExploreSearchParams(original);
+      const parsed = parseExploreParams(sp);
+      expect(parsed.params.q).toBe(original.q);
+      expect(parsed.params.radius).toBe(original.radius);
+    });
+  });
+
+  describe("canFetch", () => {
+    it("returns true when q has content", () => {
+      expect(canFetch({ q: "Boston", radius: 0.5 })).toBe(true);
+      expect(canFetch({ q: "Cambridge, MA", radius: 1.0 })).toBe(true);
+    });
+
+    it("returns false when q is empty", () => {
+      expect(canFetch({ q: "", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns false when q is whitespace only", () => {
+      expect(canFetch({ q: "   ", radius: 0.5 })).toBe(false);
+      expect(canFetch({ q: "\t\n", radius: 0.5 })).toBe(false);
+    });
+
+    it("returns true when q has content after trim", () => {
+      expect(canFetch({ q: "  Boston  ", radius: 0.5 })).toBe(true);
+    });
+  });
+});

--- a/frontend/src/lib/radiusParams.test.ts
+++ b/frontend/src/lib/radiusParams.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { RADIUS_DEFAULTS, canonicalRadius, parseRadius } from "./radiusParams";
+
+describe("radiusParams", () => {
+  describe("RADIUS_DEFAULTS", () => {
+    it("has expected constant values", () => {
+      expect(RADIUS_DEFAULTS.DEFAULT_RADIUS).toBe(0.5);
+      expect(RADIUS_DEFAULTS.MIN_RADIUS).toBe(0.1);
+      expect(RADIUS_DEFAULTS.MAX_RADIUS).toBe(3);
+      expect(RADIUS_DEFAULTS.STEP).toBe(0.1);
+      expect(RADIUS_DEFAULTS.MAX_QUERY_LENGTH).toBe(200);
+    });
+  });
+
+  describe("canonicalRadius", () => {
+    it("returns value unchanged when within bounds", () => {
+      expect(canonicalRadius(0.5)).toBe(0.5);
+      expect(canonicalRadius(1.0)).toBe(1.0);
+      expect(canonicalRadius(2.5)).toBe(2.5);
+    });
+
+    it("clamps values below MIN_RADIUS to MIN_RADIUS", () => {
+      expect(canonicalRadius(0.0)).toBe(0.1);
+      expect(canonicalRadius(-1.0)).toBe(0.1);
+      expect(canonicalRadius(0.05)).toBe(0.1);
+    });
+
+    it("clamps values above MAX_RADIUS to MAX_RADIUS", () => {
+      expect(canonicalRadius(3.0)).toBe(3.0);
+      expect(canonicalRadius(5.0)).toBe(3.0);
+      expect(canonicalRadius(10.0)).toBe(3.0);
+    });
+
+    it("rounds to one decimal place", () => {
+      expect(canonicalRadius(1.23)).toBe(1.2);
+      expect(canonicalRadius(1.26)).toBe(1.3);
+      // JavaScript Math.round rounds to nearest integer, so 1.25 * 10 = 12.5 rounds to 13, then / 10 = 1.3
+      expect(canonicalRadius(1.25)).toBe(1.3);
+      expect(canonicalRadius(0.15)).toBe(0.2);
+    });
+
+    it("handles edge cases", () => {
+      expect(canonicalRadius(0.1)).toBe(0.1);
+      expect(canonicalRadius(3.0)).toBe(3.0);
+      expect(canonicalRadius(1.99)).toBe(2.0);
+    });
+  });
+
+  describe("parseRadius", () => {
+    it("returns DEFAULT_RADIUS when input is null", () => {
+      const result = parseRadius(null);
+      expect(result.radius).toBe(RADIUS_DEFAULTS.DEFAULT_RADIUS);
+      expect(result.validationError).toBeNull();
+    });
+
+    it("returns DEFAULT_RADIUS when input is empty string", () => {
+      const result = parseRadius("");
+      expect(result.radius).toBe(RADIUS_DEFAULTS.DEFAULT_RADIUS);
+      expect(result.validationError).toBeNull();
+    });
+
+    it("parses valid numeric strings", () => {
+      expect(parseRadius("1.0")).toEqual({ radius: 1.0, validationError: null });
+      expect(parseRadius("0.5")).toEqual({ radius: 0.5, validationError: null });
+      expect(parseRadius("2.5")).toEqual({ radius: 2.5, validationError: null });
+    });
+
+    it("clamps parsed values to valid range", () => {
+      expect(parseRadius("0.0")).toEqual({ radius: 0.1, validationError: null });
+      expect(parseRadius("5.0")).toEqual({ radius: 3.0, validationError: null });
+      expect(parseRadius("-1.0")).toEqual({ radius: 0.1, validationError: null });
+    });
+
+    it("rounds parsed values to one decimal place", () => {
+      expect(parseRadius("1.23")).toEqual({ radius: 1.2, validationError: null });
+      expect(parseRadius("1.26")).toEqual({ radius: 1.3, validationError: null });
+    });
+
+    it("returns validation error for non-numeric strings", () => {
+      const result = parseRadius("not a number");
+      expect(result.radius).toBe(RADIUS_DEFAULTS.DEFAULT_RADIUS);
+      expect(result.validationError).toBe("Radius must be a number.");
+    });
+
+    it("returns validation error for NaN", () => {
+      const result = parseRadius("NaN");
+      expect(result.radius).toBe(RADIUS_DEFAULTS.DEFAULT_RADIUS);
+      expect(result.validationError).toBe("Radius must be a number.");
+    });
+
+    it("handles whitespace-only strings", () => {
+      // Number("   ") returns 0, which is then clamped to MIN_RADIUS (0.1)
+      const result = parseRadius("   ");
+      expect(result.radius).toBe(RADIUS_DEFAULTS.MIN_RADIUS);
+      expect(result.validationError).toBeNull();
+    });
+  });
+});

--- a/services/walkability.py
+++ b/services/walkability.py
@@ -61,17 +61,35 @@ _US_STREET_SPELLING = [
 ]
 
 
+def _preserve_case_replacement(matched_text, replacement):
+    """
+    Preserve the case pattern of matched_text when applying replacement.
+    - "HARBOUR" → "HARBOR" (all uppercase)
+    - "Harbour" → "Harbor" (title case)
+    - "harbour" → "harbor" (lowercase)
+    """
+    if matched_text.isupper():
+        return replacement.upper()
+    elif matched_text[0].isupper() and matched_text[1:].islower():
+        return replacement.capitalize()
+    else:
+        return replacement.lower()
+
+
 def _normalize_us_street_spelling(location_string):
     """
     Normalize common UK spellings to US for geocoding (Nominatim/OSM often use US spelling in the US).
     Returns a new string; does not modify in place.
+    Preserves the case pattern of the original text.
     """
     if not location_string or not isinstance(location_string, str):
         return location_string
     s = location_string
     for uk, us in _US_STREET_SPELLING:
-        # Case-insensitive whole-word replacement (e.g. harbour → harbor)
-        s = re.sub(rf"\b{re.escape(uk)}\b", us, s, flags=re.IGNORECASE)
+        # Case-insensitive whole-word replacement with case preservation
+        def replacer(match):
+            return _preserve_case_replacement(match.group(0), us)
+        s = re.sub(rf"\b{re.escape(uk)}\b", replacer, s, flags=re.IGNORECASE)
     return s
 
 

--- a/tests/test_error_code_sync.py
+++ b/tests/test_error_code_sync.py
@@ -27,8 +27,12 @@ def test_error_codes_sync():
     backend_codes = set()
     for line in docstring.split("\n"):
         line = line.strip()
-        if not line or line.startswith("-"):
+        if not line:
             continue
+        # Handle bullet point format: "- code: description" or "code: description"
+        # Strip leading "- " if present
+        if line.startswith("-"):
+            line = line[1:].strip()
         # Extract code from lines like "location_not_found: description"
         code_match = re.match(r"^(\w+):", line)
         if code_match:

--- a/tests/test_error_code_sync.py
+++ b/tests/test_error_code_sync.py
@@ -1,0 +1,98 @@
+"""Test that backend error codes stay in sync with frontend error messages.
+
+This test prevents a common regression: adding or changing error codes in the backend
+without updating the frontend API_ERROR_MESSAGES mapping.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+
+def test_error_codes_sync():
+    """Backend error codes documented in api/schemas.py must have frontend messages."""
+    # Read backend canonical error codes from ErrorResponse docstring
+    schemas_path = Path(__file__).parent.parent / "api" / "schemas.py"
+    schemas_content = schemas_path.read_text()
+    
+    # Extract codes from the docstring (format: "code: description")
+    docstring_match = re.search(
+        r'Canonical codes used by this API:\s*(.*?)(?=\n\s*"""|\Z)',
+        schemas_content,
+        re.DOTALL,
+    )
+    assert docstring_match, "Could not find ErrorResponse docstring with canonical codes"
+    
+    docstring = docstring_match.group(1)
+    backend_codes = set()
+    for line in docstring.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("-"):
+            continue
+        # Extract code from lines like "location_not_found: description"
+        code_match = re.match(r"^(\w+):", line)
+        if code_match:
+            backend_codes.add(code_match.group(1))
+    
+    # Also check for http_<status> pattern mentioned in docstring
+    if "http_<status>" in docstring or "http_404" in docstring or "http_422" in docstring:
+        backend_codes.add("http_404")
+        backend_codes.add("http_422")
+    
+    assert backend_codes, "No error codes found in backend docstring"
+    
+    # Read frontend error messages
+    client_path = Path(__file__).parent.parent / "frontend" / "src" / "api" / "client.ts"
+    client_content = client_path.read_text()
+    
+    # Extract codes from API_ERROR_MESSAGES object
+    messages_match = re.search(
+        r"const API_ERROR_MESSAGES[^=]*=\s*\{([^}]+)\}",
+        client_content,
+        re.DOTALL,
+    )
+    assert messages_match, "Could not find API_ERROR_MESSAGES in frontend client"
+    
+    messages_block = messages_match.group(1)
+    frontend_codes = set()
+    for line in messages_block.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("//"):
+            continue
+        # Extract code from lines like "code: message,"
+        code_match = re.match(r"^(\w+):", line)
+        if code_match:
+            frontend_codes.add(code_match.group(1))
+    
+    assert frontend_codes, "No error codes found in frontend API_ERROR_MESSAGES"
+    
+    # Check that all backend codes have frontend messages
+    missing = backend_codes - frontend_codes
+    assert not missing, (
+        f"Backend error codes missing from frontend API_ERROR_MESSAGES: {missing}. "
+        f"Add mappings in frontend/src/api/client.ts"
+    )
+    
+    # Warn about frontend codes not in backend (might be intentional, but worth checking)
+    extra = frontend_codes - backend_codes
+    if extra:
+        # These might be intentional (e.g., http_404/http_422 are documented as fallbacks)
+        # So we warn but don't fail
+        print(f"Warning: Frontend codes not in backend docstring: {extra}")
+
+
+def test_error_response_schema_matches_implementation():
+    """ErrorResponse schema fields match what the API actually returns."""
+    # This is a basic check - the actual response shape is tested in test_api.py
+    # But we can verify the schema definition is reasonable
+    from api.schemas import ErrorResponse
+    
+    # ErrorResponse should have code, message, and optional details
+    assert hasattr(ErrorResponse, "model_fields")
+    fields = ErrorResponse.model_fields
+    assert "code" in fields
+    assert "message" in fields
+    assert "details" in fields
+    
+    # details should be optional (Any | None)
+    assert fields["details"].is_required() is False

--- a/tests/test_walkability.py
+++ b/tests/test_walkability.py
@@ -14,6 +14,7 @@ from services.walkability import (
     validate_location_input,
     validate_buffer_size,
     _geocode_census,
+    _normalize_us_street_spelling,
 )
 
 
@@ -75,6 +76,51 @@ class TestInputValidation:
         is_valid, error = validate_buffer_size("not a number")
         assert is_valid is False
         assert "number" in error.lower()
+
+
+class TestNormalizeUsStreetSpelling:
+    """Test UK→US spelling normalization for geocoding."""
+    
+    def test_normalizes_harbour_to_harbor(self):
+        """Normalize 'harbour' to 'harbor'."""
+        assert _normalize_us_street_spelling("1 Harbour Way") == "1 Harbor Way"
+        assert _normalize_us_street_spelling("Harbour Street") == "Harbor Street"
+    
+    def test_normalizes_centre_to_center(self):
+        """Normalize 'centre' to 'center'."""
+        assert _normalize_us_street_spelling("City Centre") == "City Center"
+        assert _normalize_us_street_spelling("Town Centre") == "Town Center"
+    
+    def test_normalizes_multiple_variants(self):
+        """Normalize multiple UK spellings in one string."""
+        result = _normalize_us_street_spelling("Harbour Centre, Favour Street")
+        assert result == "Harbor Center, Favor Street"
+    
+    def test_case_insensitive(self):
+        """Normalization is case-insensitive."""
+        assert _normalize_us_street_spelling("HARBOUR") == "HARBOR"
+        assert _normalize_us_street_spelling("Harbour") == "Harbor"
+        assert _normalize_us_street_spelling("harbour") == "harbor"
+    
+    def test_whole_word_only(self):
+        """Only replaces whole words, not substrings."""
+        assert _normalize_us_street_spelling("harbouring") == "harbouring"  # not "harboring"
+        assert _normalize_us_street_spelling("harbourite") == "harbourite"  # not "harborite"
+    
+    def test_handles_none_and_empty(self):
+        """Returns None/empty unchanged."""
+        assert _normalize_us_street_spelling(None) is None
+        assert _normalize_us_street_spelling("") == ""
+    
+    def test_handles_non_string(self):
+        """Returns non-string input unchanged."""
+        assert _normalize_us_street_spelling(123) == 123
+        assert _normalize_us_street_spelling([]) == []
+    
+    def test_preserves_unmatched_strings(self):
+        """Strings without UK spellings are unchanged."""
+        assert _normalize_us_street_spelling("123 Main St, Boston, MA") == "123 Main St, Boston, MA"
+        assert _normalize_us_street_spelling("Normal Street Name") == "Normal Street Name"
 
 
 class TestMilesToDegrees:


### PR DESCRIPTION
Updated geocode error messages for better user guidance, introduced comprehensive tests for MapView component, and added tests for explore and compare parameter utilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test additions and copy/docs updates; the only behavior change is case-preserving UK→US spelling normalization in geocoding, which is localized and low impact.
> 
> **Overview**
> Updates backend `ErrorResponse` canonical code docs to include `service_unavailable`, and adds a backend test (`test_error_code_sync.py`) that fails if any documented backend error code is missing from the frontend `API_ERROR_MESSAGES` mapping.
> 
> Tweaks frontend geocode error copy for `location_not_found`/`http_404` and adds new frontend unit tests for `MapView` (Leaflet-mocked rendering and legend/caption behavior) and for Explore/Compare/radius URL-param parsing and validation. Backend geocoding normalization is refined to preserve original casing when converting UK→US spellings, with new tests covering the behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3190bed66f502ff3ab61f18c7f86a86e988cbb47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->