### PR TITLE
Add component analysis dashboard with improved component labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ Open http://localhost:5173 (or the URL Vite prints). The frontend uses the API a
 
 ## Usage
 
-The app includes three main pages accessible via navigation:
+The app includes four main pages accessible via navigation:
 
 - **Explore** (`/`): Search any U.S. address, ZIP code, or city and view walkability metrics on an interactive map. Set buffer and search radii to explore nearby census block groups.
 - **Compare** (`/compare`): Side-by-side comparison of two locations with summary panels and metric differences.
+- **Dashboard** (`/dashboard`): Component analysis dashboard with visualizations showing distributions, correlations, contributions, and comparisons of the four NWI components (D2A, D2B, D3B, D4A).
 - **Method** (`/method`): Documentation about the National Walkability Index methodology and data sources.
 
 ### Key Features

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -44,6 +44,10 @@ class Metrics(BaseModel):
 class BlockGroupFeature(BaseModel):
     geoid20: str | None
     natwalkind: float | None
+    d2a_ranked: float | None  # Employment and Household Mix
+    d2b_ranked: float | None  # Employment Mix
+    d3b_ranked: float | None  # Street Intersection Density
+    d4a_ranked: float | None  # Proximity to Transit Stops
     geometry: dict[str, Any]  # GeoJSON geometry object (type + coordinates)
 
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,166 @@
+# Component Analysis Dashboard
+
+The Component Analysis Dashboard provides deep insights into the four components that make up the National Walkability Index (NWI). This document describes the dashboard features, architecture, and usage.
+
+## Overview
+
+The dashboard is accessible at `/dashboard` and allows users to:
+- Analyze component score distributions across block groups
+- View correlations between components and overall NWI scores
+- Compare component contributions to walkability
+- Understand which components drive walkability in a given area
+
+## Features
+
+### 1. Component Distributions
+
+**Visualization:** Histogram showing score distributions (1-20) for all four components
+
+**Purpose:** Shows how component scores are distributed across block groups in the selected area. Helps identify if scores are clustered or spread out.
+
+**Data Source:** Individual block group component scores from the API response
+
+### 2. Component Correlations
+
+**Visualization:** Scatter plot showing relationship between component scores and NWI scores
+
+**Purpose:** Identifies which components are most strongly correlated with overall walkability. Includes:
+- Interactive component selector to view one component at a time
+- Correlation coefficients displayed for each component
+- Visual scatter plot showing the relationship
+
+**Data Source:** Block group component scores vs. NWI scores
+
+**Correlation Calculation:** Uses Pearson correlation coefficient (ranges from -1 to +1)
+
+### 3. Component Contribution
+
+**Visualization:** Bar chart comparing average component scores to NWI mean
+
+**Purpose:** Shows how each component's average compares to the overall NWI average. Includes a reference line showing the NWI mean for easy comparison.
+
+**Data Source:** Aggregated component means from the API summary response
+
+### 4. Component Comparison
+
+**Visualization:** Bar chart comparing component means, sorted by strength
+
+**Purpose:** Side-by-side comparison showing which components are strongest/weakest in the selected area. Automatically sorted by value (highest first).
+
+**Data Source:** Aggregated component means from the API summary response
+
+## Architecture
+
+### Components
+
+All dashboard components are located in `frontend/src/components/dashboard/`:
+
+- `ComponentDistributionChart.tsx` - Histogram visualization
+- `ComponentCorrelationChart.tsx` - Scatter plot with component selector
+- `ComponentContributionChart.tsx` - Bar chart with NWI reference line
+- `ComponentComparisonChart.tsx` - Sorted comparison bar chart
+- `ChartErrorBoundary.tsx` - Error boundary wrapper for charts
+
+### Shared Configuration
+
+**`frontend/src/lib/chartConfig.ts`**
+- Component color scheme (consistent across all charts)
+- Chart margin and height configurations
+- Helper functions for creating component data arrays
+
+**`frontend/src/lib/componentLabels.ts`**
+- Component labels and descriptions
+- EPA-accurate naming conventions
+- Single source of truth for component metadata
+
+**`frontend/src/lib/correlation.ts`**
+- Pearson correlation calculation utility
+- Handles null values gracefully
+
+### Error Handling
+
+All chart components are wrapped with `ChartErrorBoundary` to:
+- Prevent page crashes if Recharts encounters errors
+- Display user-friendly error messages
+- Log errors for debugging (in development mode)
+
+### Accessibility
+
+The dashboard includes:
+- ARIA labels on all charts and interactive elements
+- Keyboard navigation support
+- Screen reader friendly component selector
+- Semantic HTML structure
+
+## Component Colors
+
+The dashboard uses a consistent color scheme:
+
+- **D2A (Employment and Household Mix):** `#8884d8` (Purple)
+- **D2B (Employment Mix):** `#82ca9d` (Green)
+- **D3B (Intersection Density):** `#ffc658` (Yellow)
+- **D4A (Transit Proximity):** `#ff7300` (Orange)
+
+Colors are defined in `frontend/src/lib/chartConfig.ts` and should be updated there if changes are needed.
+
+## API Requirements
+
+The dashboard requires component scores in the API response. The `block_groups` array must include:
+- `d2a_ranked` - Employment and Household Mix score (1-20)
+- `d2b_ranked` - Employment Mix score (1-20)
+- `d3b_ranked` - Intersection Density score (1-20)
+- `d4a_ranked` - Transit Proximity score (1-20)
+
+These are included in the API response starting with schema version `2026-02-19-component-scores`.
+
+## Usage
+
+### Basic Usage
+
+1. Navigate to `/dashboard`
+2. Enter a location (address, ZIP code, or city)
+3. Adjust the radius slider (0.1-3.0 miles)
+4. Click "Analyze" to load component data
+5. View the four visualization sections
+
+### URL Parameters
+
+The dashboard uses the same URL parameter structure as the Explore page:
+- `q` - Location query string
+- `radius` - Search radius in miles
+
+Example: `/dashboard?q=Cambridge,%20MA&radius=1.0`
+
+## Future Enhancements
+
+Potential improvements based on research findings:
+
+1. **Health Outcomes Integration** - Correlate NWI components with health data
+2. **Equity Analysis** - Overlay socioeconomic indicators
+3. **Temporal Analysis** - Show changes over time (if historical data available)
+4. **Multi-location Comparison** - Compare components across multiple locations
+5. **Export Functionality** - Download charts as images or data as CSV
+
+See `docs/research/nwi-analytics-dashboard-research.md` for detailed research and recommendations.
+
+## Development Notes
+
+### Adding a New Chart
+
+1. Create component in `frontend/src/components/dashboard/`
+2. Wrap with `ChartErrorBoundary`
+3. Use colors from `chartConfig.ts`
+4. Use component labels from `componentLabels.ts`
+5. Add ARIA labels for accessibility
+6. Add to `Dashboard.tsx` page
+
+### Modifying Component Colors
+
+Update `COMPONENT_COLORS` in `frontend/src/lib/chartConfig.ts`. All charts will automatically use the new colors.
+
+### Testing
+
+- Test with various locations (urban, suburban, rural)
+- Test with different radius values
+- Verify error boundaries catch Recharts errors
+- Test keyboard navigation and screen reader compatibility

--- a/docs/research/nwi-analytics-dashboard-research.md
+++ b/docs/research/nwi-analytics-dashboard-research.md
@@ -1,127 +1,127 @@
-# National Walkability Index: Analytics & Dashboard Research
+# National Walkability Index: Analytics and Dashboard Research
 
-**Research Date:** 2026-02-19  
-**Purpose:** Inform data analytics dashboard design for NWI project
+**Research Date:** February 19, 2026  
+**Purpose:** To inform data analytics dashboard design for National Walkability Index applications
 
 ---
 
 ## Executive Summary
 
-The EPA's National Walkability Index (NWI) has been extensively researched and applied across urban planning, public health, and equity analysis. This research synthesis identifies key analytical approaches, visualization patterns, and research gaps to inform dashboard design.
+The Environmental Protection Agency's National Walkability Index (NWI) has been extensively researched and applied across urban planning, public health, and equity analysis domains. This research synthesis identifies key analytical approaches, visualization patterns, and research gaps to inform dashboard design decisions.
 
-**Key Finding:** While NWI data is widely available and validated, most existing dashboards focus on simple mapping and score display. There's opportunity for deeper analytics around health outcomes, equity analysis, spatial patterns, and comparative analysis.
+**Key Finding:** While NWI data is widely available and validated, most existing dashboards focus primarily on simple mapping and score display. Significant opportunities exist for deeper analytical capabilities including health outcomes correlation, equity analysis, spatial pattern identification, and comparative analysis.
 
 ---
 
-## 1. Existing Dashboard Examples & Patterns
+## 1. Existing Dashboard Examples and Patterns
 
 ### Major Dashboard Platforms
 
 #### **City Health Dashboard**
-- **Scale:** 0-100 (using Walk Score data, not NWI)
-- **Features:** City-level averages, neighborhood-level details
-- **Approach:** Explains why walkability matters for health outcomes
-- **Limitation:** Uses Walk Score, not NWI
+- **Scale:** 0-100 (utilizes Walk Score data, not NWI)
+- **Features:** City-level averages, neighborhood-level detail views
+- **Approach:** Emphasizes walkability's relationship to health outcomes
+- **Limitation:** Utilizes Walk Score methodology rather than NWI
 
 #### **EPA's Walkability Index (ArcGIS)**
-- **Scale:** 1-20 (NWI)
-- **Features:** Interactive map visualization, census tract level
-- **Visualization:** Quintiles for easier interpretation
-- **Data:** Based on pedestrian-oriented intersections, occupied housing, job diversity, commute modes
-- **URL:** https://experience.arcgis.com/experience/4e9b4ebfcf814fd19a73df1bd6c1ff4c/page/Walkability-Index
+- **Scale:** 1-20 (NWI standard)
+- **Features:** Interactive map visualization at census tract level
+- **Visualization:** Quintile-based categorization for interpretability
+- **Data Foundation:** Pedestrian-oriented intersections, occupied housing density, job diversity, commute mode share
+- **Reference:** https://experience.arcgis.com/experience/4e9b4ebfcf814fd19a73df1bd6c1ff4c/page/Walkability-Index
 
 #### **CTstreets Walkability Map**
-- **Features:** Multiple visualization layers (overall walkability, landscape, crime safety, traffic safety, proximity, infrastructure)
-- **Interactivity:** Toggle layers, examine at street segment and population levels
+- **Features:** Multi-layer visualization system (overall walkability, landscape, crime safety, traffic safety, proximity, infrastructure)
+- **Interactivity:** Layer toggling, examination at street segment and population levels
 - **Scale:** 5-15 minute walksheds
-- **Notable:** Combines walkability with safety metrics
+- **Notable:** Integrates walkability metrics with safety indicators
 
 #### **National Walkability Index Interactive Maps (Virginia Equity Center)**
-- **Features:** Customizable mapping tools, click-to-view scores and attributes
-- **Ranking:** Block groups based on street intersection density, transit proximity, land use diversity
-- **URL:** https://virginiaequitycenter.github.io/summer-sandbox/presentations/Walkability.html
+- **Features:** Customizable mapping tools, click-to-view score and attribute details
+- **Ranking Methodology:** Block groups ranked by street intersection density, transit proximity, land use diversity
+- **Reference:** https://virginiaequitycenter.github.io/summer-sandbox/presentations/Walkability.html
 
 ### Common Dashboard Patterns
 
-1. **Mapping-first approach:** Most dashboards lead with interactive maps
-2. **Score display:** Show NWI scores (1-20) prominently
-3. **Component breakdown:** Display individual dimensions (D2a, D2b, D3b, D4a)
-4. **Quintile visualization:** Group scores into 5 categories for easier interpretation
-5. **Population-weighted scoring:** Reflect where people actually live
+1. **Mapping-first approach:** Most dashboards employ interactive maps as the primary interface
+2. **Score display:** NWI scores (1-20 scale) displayed prominently
+3. **Component breakdown:** Individual dimension visualization (D2a, D2b, D3b, D4a)
+4. **Quintile visualization:** Score grouping into five categories for enhanced interpretability
+5. **Population-weighted scoring:** Metrics weighted to reflect actual population distribution
 
 ---
 
-## 2. Research Applications & Findings
+## 2. Research Applications and Findings
 
 ### Health Outcomes Research
 
 **Key Studies:**
-- **2015 National Health Interview Survey Analysis** (CDC/PMC)
-- **2020 National Health Interview Survey Analysis** (Wiley)
+- **2015 National Health Interview Survey Analysis** (Centers for Disease Control and Prevention/PubMed Central)
+- **2020 National Health Interview Survey Analysis** (Wiley Online Library)
 
 **Findings:**
-- **Transportation walking:** Increases from 21.6% (least walkable) to 51.6% (most walkable) — **23 percentage point increase**
-- **Leisure walking:** Increases from 48.4% to 56.5% across walkability spectrum
-- **Physical activity:** Higher walkability correlates with increased physical activity
-- **Obesity:** Reduced obesity rates in more walkable areas
-- **Urban vs Rural:** Associations strongest in urban areas, minimal in rural areas
+- **Transportation walking:** Prevalence increases from 21.6% (least walkable areas) to 51.6% (most walkable areas), representing a 23 percentage point increase
+- **Leisure walking:** Prevalence increases from 48.4% to 56.5% across the walkability spectrum
+- **Physical activity:** Higher walkability indices correlate positively with increased physical activity levels
+- **Obesity:** Reduced obesity rates observed in more walkable areas
+- **Urban vs. Rural:** Associations are strongest in urban areas, with minimal correlation observed in rural settings
 
-**Dashboard Opportunity:** Health outcomes correlation visualization (walkability vs. walking rates, obesity rates)
+**Dashboard Opportunity:** Health outcomes correlation visualization capabilities (walkability index versus walking rates, obesity rates)
 
-### Equity & Environmental Justice Research
+### Equity and Environmental Justice Research
 
 **Key Studies:**
-- **Nationwide analysis of socially vulnerable populations** (MDPI)
-- **Comparative study:** Charlotte, NC; Pittsburgh, PA; Portland, OR (Taylor & Francis)
-- **Environmental Justice in 15-Minute City** (MDPI)
+- **Nationwide analysis of socially vulnerable populations** (Multidisciplinary Digital Publishing Institute)
+- **Comparative study:** Charlotte, North Carolina; Pittsburgh, Pennsylvania; Portland, Oregon (Taylor & Francis)
+- **Environmental Justice in 15-Minute City** (Multidisciplinary Digital Publishing Institute)
 
 **Findings:**
-- **Racial disparities:** Communities of color live in less-walkable neighborhoods with fewer street lights, higher speed limits, more police stops
-- **City variability:** Significant differences in equitable access across cities
-  - Charlotte: Greatest inequity, most "walk-vulnerable" areas
-  - Portland & Pittsburgh: More equitable, but unique spatial distributions
-- **Social vulnerability:** High social vulnerability + low walkability = "walk-vulnerable" areas
-- **Infrastructure gaps:** Less walkable areas have fewer amenities, worse infrastructure
+- **Racial disparities:** Communities of color disproportionately reside in less-walkable neighborhoods characterized by fewer street lights, higher speed limits, and increased police stops
+- **City variability:** Significant differences in equitable access observed across metropolitan areas
+  - Charlotte: Exhibits greatest inequity, with highest concentration of "walk-vulnerable" areas
+  - Portland and Pittsburgh: Demonstrate more equitable distributions, though with distinct spatial patterns
+- **Social vulnerability:** Areas with high social vulnerability indices combined with low walkability scores constitute "walk-vulnerable" neighborhoods
+- **Infrastructure gaps:** Less walkable areas demonstrate fewer amenities and inferior infrastructure quality
 
-**Dashboard Opportunity:** Equity analysis overlays (NWI vs. socioeconomic indicators, racial demographics, social vulnerability index)
+**Dashboard Opportunity:** Equity analysis overlay capabilities (NWI versus socioeconomic indicators, racial demographics, social vulnerability index)
 
 ### Spatial Pattern Analysis
 
 **Key Patterns Identified:**
-- **Rural areas:** Score ~1.2
-- **Suburban residential:** Score ~8.3
-- **Historic main streets/downtowns:** Score ~13.7
-- **City centers/suburban town centers:** Score ~17.5+
+- **Rural areas:** Average score approximately 1.2
+- **Suburban residential:** Average score approximately 8.3
+- **Historic main streets and downtowns:** Average score approximately 13.7
+- **City centers and suburban town centers:** Average score 17.5 and above
 
 **Research Applications:**
-- GIS analysis of urban development patterns
-- Spatial correlation with transportation behavior
-- Regional comparisons (metropolitan areas, states)
+- Geographic Information Systems analysis of urban development patterns
+- Spatial correlation analysis with transportation behavior
+- Regional comparative analysis (metropolitan areas, state-level comparisons)
 
-**Dashboard Opportunity:** Spatial pattern analysis (heat maps, regional comparisons, urban-rural gradients)
+**Dashboard Opportunity:** Spatial pattern analysis capabilities (heat maps, regional comparisons, urban-rural gradient visualizations)
 
 ---
 
-## 3. Research Gaps & Opportunities
+## 3. Research Gaps and Opportunities
 
-### What's Missing in Existing Dashboards
+### Limitations in Existing Dashboards
 
-1. **Health outcomes integration:** Most dashboards show scores but don't visualize health correlations
-2. **Equity analysis:** Limited integration of socioeconomic and demographic overlays
-3. **Temporal analysis:** NWI is static; few dashboards show trends or changes over time
-4. **Comparative analytics:** Limited side-by-side comparison tools (your Compare page addresses this!)
-5. **Component analysis:** Most show composite scores but don't deeply analyze individual dimensions
-6. **Contextual analysis:** Limited integration with complementary datasets (e.g., WAS, Walk Score, crime data)
+1. **Health outcomes integration:** Most dashboards display scores but lack health correlation visualizations
+2. **Equity analysis:** Limited integration of socioeconomic and demographic overlay capabilities
+3. **Temporal analysis:** NWI data is static; few dashboards demonstrate temporal trends or change analysis
+4. **Comparative analytics:** Limited side-by-side comparison functionality
+5. **Component analysis:** Most dashboards display composite scores but lack deep analysis of individual dimensions
+6. **Contextual analysis:** Limited integration with complementary datasets (e.g., Walkable Accessibility Score, Walk Score, crime data)
 
-### Unique Opportunities for Your Dashboard
+### Identified Opportunities for Enhanced Dashboard Capabilities
 
-Based on your existing project structure:
+Based on current project architecture:
 
-1. **Multi-location comparison:** Your `/compare` route is ahead of most existing dashboards
-2. **Component dimension analysis:** Deep dive into D2a, D2b, D3b, D4a relationships
-3. **"Nearby better" analytics:** Your delta-based search is unique
-4. **Integration potential:** WAS (Walkable Accessibility Score) integration for "hollow neighborhood" detection
-5. **Custom radius analysis:** Your buffer/search radius flexibility enables unique insights
+1. **Multi-location comparison:** Comparative analysis functionality exceeds capabilities of most existing dashboards
+2. **Component dimension analysis:** In-depth examination of D2a, D2b, D3b, D4a dimension relationships
+3. **Delta-based search analytics:** Unique capability for identifying areas with improved walkability metrics
+4. **Integration potential:** Walkable Accessibility Score (WAS) integration for "hollow neighborhood" detection
+5. **Custom radius analysis:** Flexible buffer and search radius parameters enable unique analytical insights
 
 ---
 
@@ -130,119 +130,119 @@ Based on your existing project structure:
 ### Core Analytics (High Priority)
 
 1. **Health Outcomes Correlation**
-   - NWI score vs. transportation walking rates
-   - NWI score vs. leisure walking rates
-   - NWI score vs. obesity rates (if data available)
-   - Urban vs. rural breakdowns
+   - NWI score versus transportation walking rates
+   - NWI score versus leisure walking rates
+   - NWI score versus obesity rates (subject to data availability)
+   - Urban versus rural breakdowns
 
 2. **Equity Analysis**
-   - NWI score vs. socioeconomic indicators
-   - NWI score vs. racial demographics
+   - NWI score versus socioeconomic indicators
+   - NWI score versus racial demographics
    - Social vulnerability index overlay
    - "Walk-vulnerable" area identification
 
 3. **Component Dimension Analysis**
-   - D2a (Employment & Housing Mix) distribution
+   - D2a (Employment and Housing Mix) distribution
    - D2b (Employment Diversity) distribution
    - D3b (Intersection Density) distribution
    - D4a (Transit Proximity) distribution
    - Component correlation matrix
-   - Which components drive high/low scores?
+   - Identification of components driving high/low scores
 
 4. **Spatial Pattern Analysis**
-   - Regional comparisons (metropolitan areas, states)
+   - Regional comparisons (metropolitan areas, state-level)
    - Urban-rural gradient visualization
    - Score distribution histograms
    - Geographic clustering analysis
 
 ### Advanced Analytics (Medium Priority)
 
-5. **Comparative Analytics** (enhance existing `/compare`)
-   - Multi-location comparison (3+ locations)
+5. **Comparative Analytics** (enhancement of existing comparison functionality)
+   - Multi-location comparison (three or more locations)
    - Component-by-component comparison
    - Score difference visualization
-   - "Better" candidate analysis with multiple criteria
+   - Multi-criteria candidate analysis
 
-6. **Temporal Analysis** (if historical data available)
+6. **Temporal Analysis** (subject to historical data availability)
    - Score changes over time
    - Neighborhood momentum indicators
-   - Stability vs. change patterns
+   - Stability versus change pattern identification
 
 7. **Integration Analytics**
-   - NWI vs. WAS (Walkable Accessibility Score) correlation
+   - NWI versus Walkable Accessibility Score (WAS) correlation
    - "Hollow neighborhood" detection (high NWI, low WAS)
-   - Multi-metric composite scores
+   - Multi-metric composite score generation
 
 ### Visualization Patterns to Adopt
 
-- **Quintile grouping:** Group scores into 5 categories for easier interpretation
-- **Population-weighted metrics:** Reflect where people actually live
-- **Layer toggles:** Allow users to show/hide different data layers
+- **Quintile grouping:** Score categorization into five groups for enhanced interpretability
+- **Population-weighted metrics:** Metrics weighted to reflect actual population distribution
+- **Layer toggles:** User-controlled display of different data layers
 - **Interactive tooltips:** Click-to-view detailed scores and attributes
-- **Comparative views:** Side-by-side or overlay comparisons
+- **Comparative views:** Side-by-side or overlay comparison capabilities
 
 ---
 
-## 5. Data Sources & Integration Opportunities
+## 5. Data Sources and Integration Opportunities
 
 ### Complementary Datasets
 
 1. **Walkable Accessibility Score (WAS)**
-   - Pre-calculated: `US_WAS_1997_2019` shapefile
-   - Temporal data: 1997-2019
-   - Validated against Walk Score (ρ=0.912)
-   - See: `docs/walkable_accessibility_score_paper_notes.md`
+   - Pre-calculated dataset: `US_WAS_1997_2019` shapefile
+   - Temporal coverage: 1997-2019
+   - Validation: Correlation coefficient of 0.912 against Walk Score
+   - Reference documentation: `docs/walkable_accessibility_score_paper_notes.md`
 
 2. **Health Data**
    - National Health Interview Survey (NHIS) data
-   - CDC health outcome data
-   - Obesity rates by geography
+   - Centers for Disease Control and Prevention health outcome data
+   - Obesity rates by geographic area
 
 3. **Equity Data**
-   - Social Vulnerability Index (CDC)
+   - Social Vulnerability Index (Centers for Disease Control and Prevention)
    - Census demographic data
    - American Community Survey (ACS) data
 
 4. **Transportation Data**
-   - Transit stop locations
-   - Commute mode data
-   - Transportation infrastructure
+   - Transit stop location data
+   - Commute mode share data
+   - Transportation infrastructure datasets
 
 ### Integration Strategy
 
-- **Spatial joins:** Join by GEOID (Census Block Group identifier)
-- **API endpoints:** Consider adding analytics endpoints to your FastAPI backend
-- **Caching:** Pre-compute common analytics queries
-- **Incremental loading:** Load complementary datasets on-demand
+- **Spatial joins:** Join operations using GEOID (Census Block Group identifier)
+- **API endpoints:** Consider implementing analytics endpoints within the FastAPI backend
+- **Caching:** Pre-computation of common analytics queries
+- **Incremental loading:** On-demand loading of complementary datasets
 
 ---
 
-## 6. Research Citations & References
+## 6. Research Citations and References
 
 ### Key Papers
 
 1. **Associations between the National Walkability Index and walking among US Adults — National Health Interview Survey, 2015**
-   - CDC: https://stacks.cdc.gov/view/cdc/111032
-   - PMC: https://pmc.ncbi.nlm.nih.gov/articles/PMC8544176/
-   - Key finding: 21.6% → 51.6% transportation walking increase
+   - Centers for Disease Control and Prevention: https://stacks.cdc.gov/view/cdc/111032
+   - PubMed Central: https://pmc.ncbi.nlm.nih.gov/articles/PMC8544176/
+   - Key finding: Transportation walking prevalence increases from 21.6% to 51.6%
 
 2. **Higher Walkability Associated with Increased Physical Activity and Reduced Obesity among U.S. Adults**
-   - PMC: https://pmc.ncbi.nlm.nih.gov/articles/PMC9877111/
-   - Wiley: https://onlinelibrary.wiley.com/doi/10.1002/oby.23634
+   - PubMed Central: https://pmc.ncbi.nlm.nih.gov/articles/PMC9877111/
+   - Wiley Online Library: https://onlinelibrary.wiley.com/doi/10.1002/oby.23634
 
 3. **Do Socially Vulnerable Urban Populations Have Access to Walkable, Transit-Accessible Neighborhoods?**
-   - MDPI: https://www.mdpi.com/2413-8851/7/1/6
+   - Multidisciplinary Digital Publishing Institute: https://www.mdpi.com/2413-8851/7/1/6
 
 4. **Equity in neighbourhood walkability? A comparative analysis of three large U.S. cities**
    - Taylor & Francis: https://www.tandfonline.com/doi/full/10.1080/13549839.2017.1297390
 
 5. **Walkability Indices—The State of the Art and Future Directions: A Systematic Review**
-   - MDPI: https://www.mdpi.com/2071-1050/16/16/6730
+   - Multidisciplinary Digital Publishing Institute: https://www.mdpi.com/2071-1050/16/16/6730
 
 ### Official Resources
 
-- **EPA National Walkability Index User Guide:** https://www.epa.gov/smartgrowth/national-walkability-index-user-guide-and-methodology
-- **EPA Methodology PDF:** https://www.epa.gov/sites/default/files/2021-06/documents/national_walkability_index_methodology_and_user_guide_june2021.pdf
+- **Environmental Protection Agency National Walkability Index User Guide:** https://www.epa.gov/smartgrowth/national-walkability-index-user-guide-and-methodology
+- **Environmental Protection Agency Methodology PDF:** https://www.epa.gov/sites/default/files/2021-06/documents/national_walkability_index_methodology_and_user_guide_june2021.pdf
 - **Data.gov:** https://catalog.data.gov/dataset/walkability-index8
 - **ArcGIS REST Service:** https://gispub.epa.gov/arcgis/rest/services/OA/WalkabilityIndex/MapServer
 
@@ -250,39 +250,39 @@ Based on your existing project structure:
 
 ## 7. Recommendations for Dashboard Design
 
-### Phase 1: Core Analytics (MVP)
-- Health outcomes correlation charts
+### Phase 1: Core Analytics (Minimum Viable Product)
+- Health outcomes correlation visualizations
 - Component dimension analysis
 - Spatial pattern visualizations
 - Enhanced comparison tools
 
-### Phase 2: Equity & Integration
-- Equity analysis overlays
-- WAS integration for "hollow neighborhood" detection
+### Phase 2: Equity and Integration
+- Equity analysis overlay capabilities
+- Walkable Accessibility Score integration for "hollow neighborhood" detection
 - Multi-metric composite views
 
 ### Phase 3: Advanced Analytics
-- Temporal analysis (if data available)
-- Predictive analytics
-- Custom query builder
+- Temporal analysis (subject to data availability)
+- Predictive analytics capabilities
+- Custom query builder functionality
 
 ### Design Principles
-- **Research-backed:** Ground visualizations in validated research findings
-- **Accessible:** Use quintiles and clear labels for general audiences
-- **Interactive:** Enable exploration, not just display
-- **Contextual:** Provide interpretation guidance and limitations
-- **Comparative:** Leverage your unique multi-location comparison capability
+- **Research-backed:** Visualizations grounded in validated research findings
+- **Accessible:** Utilization of quintiles and clear labeling for general audiences
+- **Interactive:** Enable exploratory analysis rather than static display
+- **Contextual:** Provide interpretation guidance and methodological limitations
+- **Comparative:** Leverage multi-location comparison capabilities
 
 ---
 
 ## Next Steps
 
-1. **Prioritize features** based on research findings and user needs
+1. **Prioritize features** based on research findings and user requirements
 2. **Design mockups** for core analytics visualizations
-3. **Plan data integration** for complementary datasets (WAS, health, equity)
-4. **Create session** in `docs/sessions/active/` for dashboard development
-5. **Reference this document** during dashboard design and development
+3. **Plan data integration** for complementary datasets (Walkable Accessibility Score, health, equity)
+4. **Create development session** in `docs/sessions/active/` for dashboard implementation
+5. **Reference this document** during dashboard design and development phases
 
 ---
 
-*Research compiled from web searches, academic papers, and existing dashboard analysis. Last updated: 2026-02-19*
+*Research compiled from web searches, academic papers, and existing dashboard analysis. Last updated: February 19, 2026*

--- a/docs/research/nwi-analytics-dashboard-research.md
+++ b/docs/research/nwi-analytics-dashboard-research.md
@@ -1,0 +1,288 @@
+# National Walkability Index: Analytics & Dashboard Research
+
+**Research Date:** 2026-02-19  
+**Purpose:** Inform data analytics dashboard design for NWI project
+
+---
+
+## Executive Summary
+
+The EPA's National Walkability Index (NWI) has been extensively researched and applied across urban planning, public health, and equity analysis. This research synthesis identifies key analytical approaches, visualization patterns, and research gaps to inform dashboard design.
+
+**Key Finding:** While NWI data is widely available and validated, most existing dashboards focus on simple mapping and score display. There's opportunity for deeper analytics around health outcomes, equity analysis, spatial patterns, and comparative analysis.
+
+---
+
+## 1. Existing Dashboard Examples & Patterns
+
+### Major Dashboard Platforms
+
+#### **City Health Dashboard**
+- **Scale:** 0-100 (using Walk Score data, not NWI)
+- **Features:** City-level averages, neighborhood-level details
+- **Approach:** Explains why walkability matters for health outcomes
+- **Limitation:** Uses Walk Score, not NWI
+
+#### **EPA's Walkability Index (ArcGIS)**
+- **Scale:** 1-20 (NWI)
+- **Features:** Interactive map visualization, census tract level
+- **Visualization:** Quintiles for easier interpretation
+- **Data:** Based on pedestrian-oriented intersections, occupied housing, job diversity, commute modes
+- **URL:** https://experience.arcgis.com/experience/4e9b4ebfcf814fd19a73df1bd6c1ff4c/page/Walkability-Index
+
+#### **CTstreets Walkability Map**
+- **Features:** Multiple visualization layers (overall walkability, landscape, crime safety, traffic safety, proximity, infrastructure)
+- **Interactivity:** Toggle layers, examine at street segment and population levels
+- **Scale:** 5-15 minute walksheds
+- **Notable:** Combines walkability with safety metrics
+
+#### **National Walkability Index Interactive Maps (Virginia Equity Center)**
+- **Features:** Customizable mapping tools, click-to-view scores and attributes
+- **Ranking:** Block groups based on street intersection density, transit proximity, land use diversity
+- **URL:** https://virginiaequitycenter.github.io/summer-sandbox/presentations/Walkability.html
+
+### Common Dashboard Patterns
+
+1. **Mapping-first approach:** Most dashboards lead with interactive maps
+2. **Score display:** Show NWI scores (1-20) prominently
+3. **Component breakdown:** Display individual dimensions (D2a, D2b, D3b, D4a)
+4. **Quintile visualization:** Group scores into 5 categories for easier interpretation
+5. **Population-weighted scoring:** Reflect where people actually live
+
+---
+
+## 2. Research Applications & Findings
+
+### Health Outcomes Research
+
+**Key Studies:**
+- **2015 National Health Interview Survey Analysis** (CDC/PMC)
+- **2020 National Health Interview Survey Analysis** (Wiley)
+
+**Findings:**
+- **Transportation walking:** Increases from 21.6% (least walkable) to 51.6% (most walkable) — **23 percentage point increase**
+- **Leisure walking:** Increases from 48.4% to 56.5% across walkability spectrum
+- **Physical activity:** Higher walkability correlates with increased physical activity
+- **Obesity:** Reduced obesity rates in more walkable areas
+- **Urban vs Rural:** Associations strongest in urban areas, minimal in rural areas
+
+**Dashboard Opportunity:** Health outcomes correlation visualization (walkability vs. walking rates, obesity rates)
+
+### Equity & Environmental Justice Research
+
+**Key Studies:**
+- **Nationwide analysis of socially vulnerable populations** (MDPI)
+- **Comparative study:** Charlotte, NC; Pittsburgh, PA; Portland, OR (Taylor & Francis)
+- **Environmental Justice in 15-Minute City** (MDPI)
+
+**Findings:**
+- **Racial disparities:** Communities of color live in less-walkable neighborhoods with fewer street lights, higher speed limits, more police stops
+- **City variability:** Significant differences in equitable access across cities
+  - Charlotte: Greatest inequity, most "walk-vulnerable" areas
+  - Portland & Pittsburgh: More equitable, but unique spatial distributions
+- **Social vulnerability:** High social vulnerability + low walkability = "walk-vulnerable" areas
+- **Infrastructure gaps:** Less walkable areas have fewer amenities, worse infrastructure
+
+**Dashboard Opportunity:** Equity analysis overlays (NWI vs. socioeconomic indicators, racial demographics, social vulnerability index)
+
+### Spatial Pattern Analysis
+
+**Key Patterns Identified:**
+- **Rural areas:** Score ~1.2
+- **Suburban residential:** Score ~8.3
+- **Historic main streets/downtowns:** Score ~13.7
+- **City centers/suburban town centers:** Score ~17.5+
+
+**Research Applications:**
+- GIS analysis of urban development patterns
+- Spatial correlation with transportation behavior
+- Regional comparisons (metropolitan areas, states)
+
+**Dashboard Opportunity:** Spatial pattern analysis (heat maps, regional comparisons, urban-rural gradients)
+
+---
+
+## 3. Research Gaps & Opportunities
+
+### What's Missing in Existing Dashboards
+
+1. **Health outcomes integration:** Most dashboards show scores but don't visualize health correlations
+2. **Equity analysis:** Limited integration of socioeconomic and demographic overlays
+3. **Temporal analysis:** NWI is static; few dashboards show trends or changes over time
+4. **Comparative analytics:** Limited side-by-side comparison tools (your Compare page addresses this!)
+5. **Component analysis:** Most show composite scores but don't deeply analyze individual dimensions
+6. **Contextual analysis:** Limited integration with complementary datasets (e.g., WAS, Walk Score, crime data)
+
+### Unique Opportunities for Your Dashboard
+
+Based on your existing project structure:
+
+1. **Multi-location comparison:** Your `/compare` route is ahead of most existing dashboards
+2. **Component dimension analysis:** Deep dive into D2a, D2b, D3b, D4a relationships
+3. **"Nearby better" analytics:** Your delta-based search is unique
+4. **Integration potential:** WAS (Walkable Accessibility Score) integration for "hollow neighborhood" detection
+5. **Custom radius analysis:** Your buffer/search radius flexibility enables unique insights
+
+---
+
+## 4. Recommended Dashboard Features
+
+### Core Analytics (High Priority)
+
+1. **Health Outcomes Correlation**
+   - NWI score vs. transportation walking rates
+   - NWI score vs. leisure walking rates
+   - NWI score vs. obesity rates (if data available)
+   - Urban vs. rural breakdowns
+
+2. **Equity Analysis**
+   - NWI score vs. socioeconomic indicators
+   - NWI score vs. racial demographics
+   - Social vulnerability index overlay
+   - "Walk-vulnerable" area identification
+
+3. **Component Dimension Analysis**
+   - D2a (Employment & Housing Mix) distribution
+   - D2b (Employment Diversity) distribution
+   - D3b (Intersection Density) distribution
+   - D4a (Transit Proximity) distribution
+   - Component correlation matrix
+   - Which components drive high/low scores?
+
+4. **Spatial Pattern Analysis**
+   - Regional comparisons (metropolitan areas, states)
+   - Urban-rural gradient visualization
+   - Score distribution histograms
+   - Geographic clustering analysis
+
+### Advanced Analytics (Medium Priority)
+
+5. **Comparative Analytics** (enhance existing `/compare`)
+   - Multi-location comparison (3+ locations)
+   - Component-by-component comparison
+   - Score difference visualization
+   - "Better" candidate analysis with multiple criteria
+
+6. **Temporal Analysis** (if historical data available)
+   - Score changes over time
+   - Neighborhood momentum indicators
+   - Stability vs. change patterns
+
+7. **Integration Analytics**
+   - NWI vs. WAS (Walkable Accessibility Score) correlation
+   - "Hollow neighborhood" detection (high NWI, low WAS)
+   - Multi-metric composite scores
+
+### Visualization Patterns to Adopt
+
+- **Quintile grouping:** Group scores into 5 categories for easier interpretation
+- **Population-weighted metrics:** Reflect where people actually live
+- **Layer toggles:** Allow users to show/hide different data layers
+- **Interactive tooltips:** Click-to-view detailed scores and attributes
+- **Comparative views:** Side-by-side or overlay comparisons
+
+---
+
+## 5. Data Sources & Integration Opportunities
+
+### Complementary Datasets
+
+1. **Walkable Accessibility Score (WAS)**
+   - Pre-calculated: `US_WAS_1997_2019` shapefile
+   - Temporal data: 1997-2019
+   - Validated against Walk Score (ρ=0.912)
+   - See: `docs/walkable_accessibility_score_paper_notes.md`
+
+2. **Health Data**
+   - National Health Interview Survey (NHIS) data
+   - CDC health outcome data
+   - Obesity rates by geography
+
+3. **Equity Data**
+   - Social Vulnerability Index (CDC)
+   - Census demographic data
+   - American Community Survey (ACS) data
+
+4. **Transportation Data**
+   - Transit stop locations
+   - Commute mode data
+   - Transportation infrastructure
+
+### Integration Strategy
+
+- **Spatial joins:** Join by GEOID (Census Block Group identifier)
+- **API endpoints:** Consider adding analytics endpoints to your FastAPI backend
+- **Caching:** Pre-compute common analytics queries
+- **Incremental loading:** Load complementary datasets on-demand
+
+---
+
+## 6. Research Citations & References
+
+### Key Papers
+
+1. **Associations between the National Walkability Index and walking among US Adults — National Health Interview Survey, 2015**
+   - CDC: https://stacks.cdc.gov/view/cdc/111032
+   - PMC: https://pmc.ncbi.nlm.nih.gov/articles/PMC8544176/
+   - Key finding: 21.6% → 51.6% transportation walking increase
+
+2. **Higher Walkability Associated with Increased Physical Activity and Reduced Obesity among U.S. Adults**
+   - PMC: https://pmc.ncbi.nlm.nih.gov/articles/PMC9877111/
+   - Wiley: https://onlinelibrary.wiley.com/doi/10.1002/oby.23634
+
+3. **Do Socially Vulnerable Urban Populations Have Access to Walkable, Transit-Accessible Neighborhoods?**
+   - MDPI: https://www.mdpi.com/2413-8851/7/1/6
+
+4. **Equity in neighbourhood walkability? A comparative analysis of three large U.S. cities**
+   - Taylor & Francis: https://www.tandfonline.com/doi/full/10.1080/13549839.2017.1297390
+
+5. **Walkability Indices—The State of the Art and Future Directions: A Systematic Review**
+   - MDPI: https://www.mdpi.com/2071-1050/16/16/6730
+
+### Official Resources
+
+- **EPA National Walkability Index User Guide:** https://www.epa.gov/smartgrowth/national-walkability-index-user-guide-and-methodology
+- **EPA Methodology PDF:** https://www.epa.gov/sites/default/files/2021-06/documents/national_walkability_index_methodology_and_user_guide_june2021.pdf
+- **Data.gov:** https://catalog.data.gov/dataset/walkability-index8
+- **ArcGIS REST Service:** https://gispub.epa.gov/arcgis/rest/services/OA/WalkabilityIndex/MapServer
+
+---
+
+## 7. Recommendations for Dashboard Design
+
+### Phase 1: Core Analytics (MVP)
+- Health outcomes correlation charts
+- Component dimension analysis
+- Spatial pattern visualizations
+- Enhanced comparison tools
+
+### Phase 2: Equity & Integration
+- Equity analysis overlays
+- WAS integration for "hollow neighborhood" detection
+- Multi-metric composite views
+
+### Phase 3: Advanced Analytics
+- Temporal analysis (if data available)
+- Predictive analytics
+- Custom query builder
+
+### Design Principles
+- **Research-backed:** Ground visualizations in validated research findings
+- **Accessible:** Use quintiles and clear labels for general audiences
+- **Interactive:** Enable exploration, not just display
+- **Contextual:** Provide interpretation guidance and limitations
+- **Comparative:** Leverage your unique multi-location comparison capability
+
+---
+
+## Next Steps
+
+1. **Prioritize features** based on research findings and user needs
+2. **Design mockups** for core analytics visualizations
+3. **Plan data integration** for complementary datasets (WAS, health, equity)
+4. **Create session** in `docs/sessions/active/` for dashboard development
+5. **Reference this document** during dashboard design and development
+
+---
+
+*Research compiled from web searches, academic papers, and existing dashboard analysis. Last updated: 2026-02-19*

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.575.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.0"
+        "react-router-dom": "^7.13.0",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1263,6 +1264,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1624,7 +1661,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
@@ -1767,6 +1809,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1819,7 +1924,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1834,6 +1939,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.55.0",
@@ -2470,6 +2581,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2583,8 +2703,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2623,6 +2864,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -2676,6 +2923,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2936,6 +3193,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3165,6 +3428,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3200,6 +3473,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -3794,9 +4076,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3846,6 +4150,36 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3860,6 +4194,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3869,6 +4218,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4058,6 +4413,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -4270,6 +4631,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.0"
+    "react-router-dom": "^7.13.0",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,5 +1,41 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true" role="img">
   <title>Walkability Explorer</title>
-  <!-- City skyline: buildings of varying heights -->
-  <path fill="#1e40af" d="M0 32h4V18H0v14zm6 0h4V12h-4v20zm8 0h4V8h-4v24zm6 0h4V14h-4v18zm8 0h4V6h-4v26zm6 0h4V10h-4v22zm6 0h6V14h-6v18z"/>
+  <!-- Creative cityscape with windows and varied building shapes -->
+  
+  <!-- Left building (shorter) -->
+  <rect x="2" y="20" width="5" height="10" fill="#2563eb"/>
+  <rect x="3" y="22" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="5" y="22" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="3" y="25" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="5" y="25" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  
+  <!-- Middle building (tallest) -->
+  <rect x="8" y="8" width="6" height="22" fill="#2563eb"/>
+  <!-- Windows on tall building -->
+  <rect x="9.5" y="12" width="1" height="1.5" fill="#ffffff" opacity="0.8"/>
+  <rect x="11.5" y="12" width="1" height="1.5" fill="#ffffff" opacity="0.8"/>
+  <rect x="9.5" y="15" width="1" height="1.5" fill="#ffffff" opacity="0.8"/>
+  <rect x="11.5" y="15" width="1" height="1.5" fill="#ffffff" opacity="0.8"/>
+  <rect x="9.5" y="18" width="1" height="1.5" fill="#ffffff" opacity="0.8"/>
+  <rect x="11.5" y="18" width="1" height="1.5" fill="#ffffff" opacity="0.8"/>
+  
+  <!-- Right building (medium height with slanted roof) -->
+  <rect x="15" y="16" width="5" height="14" fill="#2563eb"/>
+  <polygon points="15,16 17.5,12 20,16" fill="#1e40af"/>
+  <!-- Windows -->
+  <rect x="16" y="19" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="18" y="19" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="16" y="22" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="18" y="22" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  
+  <!-- Far right building (narrow, tall) -->
+  <rect x="22" y="12" width="3" height="18" fill="#2563eb"/>
+  <rect x="22.5" y="15" width="0.8" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="22.5" y="18" width="0.8" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="22.5" y="21" width="0.8" height="1" fill="#ffffff" opacity="0.8"/>
+  
+  <!-- Small building on far right -->
+  <rect x="26" y="24" width="4" height="6" fill="#2563eb"/>
+  <rect x="27" y="26" width="1" height="1" fill="#ffffff" opacity="0.8"/>
+  <rect x="28.5" y="26" width="1" height="1" fill="#ffffff" opacity="0.8"/>
 </svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -794,3 +794,160 @@
   border-radius: 8px;
   font-size: 1.1rem;
 }
+
+/* Dashboard page styles */
+
+.dashboard {
+  max-width: 1200px;
+}
+
+.dashboard__header {
+  margin-bottom: 2rem;
+}
+
+.dashboard__header h1 {
+  font-size: 1.75rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.dashboard__tagline {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.dashboard__controls {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.dashboard__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dashboard__form label {
+  font-weight: 500;
+  color: #374151;
+}
+
+.dashboard__form input[type="text"] {
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.dashboard__radius {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard__radius input[type="range"] {
+  width: 100%;
+}
+
+.dashboard__form button {
+  padding: 0.75rem 1.5rem;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.dashboard__form button:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.dashboard__form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dashboard__error {
+  padding: 1rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 4px;
+  color: #991b1b;
+  margin-bottom: 1.5rem;
+}
+
+.dashboard__empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: #6b7280;
+  background: #fafafa;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.dashboard__empty-hint {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: #9ca3af;
+}
+
+.dashboard__visualizations {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.dashboard__section {
+  padding: 1.5rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.dashboard__section h2 {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem 0;
+  color: #111;
+}
+
+.dashboard__section-description {
+  margin: 0 0 1.5rem 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.correlation-charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.correlation-summary {
+  padding: 1rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+}
+
+.correlation-summary h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  color: #111;
+}
+
+.correlation-summary ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  list-style: disc;
+}
+
+.correlation-summary li {
+  margin-bottom: 0.5rem;
+  color: #374151;
+  font-size: 0.9rem;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -951,3 +951,92 @@
   color: #374151;
   font-size: 0.9rem;
 }
+
+.correlation-component-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.correlation-selector-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0.75rem;
+  border: 2px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+}
+
+.correlation-selector-btn:hover {
+  border-color: #2563eb;
+  background: #f0f7ff;
+}
+
+.correlation-selector-btn:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.correlation-selector-btn--active {
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+.correlation-selector-code {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #1e40af;
+  margin-bottom: 0.25rem;
+}
+
+.correlation-selector-label {
+  font-size: 0.85rem;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.correlation-selector-value {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #111;
+}
+
+.correlation-chart-container {
+  margin-top: 1.5rem;
+}
+
+.correlation-chart-note {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  text-align: center;
+}
+
+.chart-error {
+  padding: 2rem;
+  text-align: center;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #991b1b;
+}
+
+.chart-error p {
+  margin: 0 0 0.5rem 0;
+}
+
+.chart-error details {
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.chart-error summary {
+  cursor: pointer;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from "./layouts/AppLayout";
 import { Explore } from "./pages/Explore";
 import { Compare } from "./pages/Compare";
 import { Method } from "./pages/Method";
+import { Dashboard } from "./pages/Dashboard";
 import "./App.css";
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
         <Route element={<AppLayout />}>
           <Route index element={<Explore />} />
           <Route path="compare" element={<Compare />} />
+          <Route path="dashboard" element={<Dashboard />} />
           <Route path="method" element={<Method />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { NavLink } from "react-router-dom";
 const navLinks = [
   { to: "/", label: "Explore", end: true },
   { to: "/compare", label: "Compare", end: false },
+  { to: "/dashboard", label: "Dashboard", end: false },
   { to: "/method", label: "Method", end: false },
 ] as const;
 

--- a/frontend/src/components/dashboard/ChartErrorBoundary.tsx
+++ b/frontend/src/components/dashboard/ChartErrorBoundary.tsx
@@ -1,0 +1,59 @@
+/**
+ * Error boundary for chart components to prevent crashes from Recharts errors.
+ */
+
+import { Component, type ReactNode } from "react";
+
+interface ChartErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  chartName?: string;
+}
+
+interface ChartErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ChartErrorBoundary extends Component<ChartErrorBoundaryProps, ChartErrorBoundaryState> {
+  constructor(props: ChartErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ChartErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: unknown) {
+    // Log error for debugging (in production, you might want to send to error tracking service)
+    console.error(`Chart error in ${this.props.chartName || "chart"}:`, error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div className="chart-error" role="alert" aria-live="polite">
+            <p>
+              <strong>Unable to display chart.</strong>
+            </p>
+            <p style={{ fontSize: "0.9rem", color: "#6b7280", marginTop: "0.5rem" }}>
+              {this.props.chartName ? `Error loading ${this.props.chartName}.` : "An error occurred while rendering the chart."}
+            </p>
+            {process.env.NODE_ENV === "development" && this.state.error && (
+              <details style={{ marginTop: "0.5rem", fontSize: "0.85rem" }}>
+                <summary>Error details (development only)</summary>
+                <pre style={{ marginTop: "0.5rem", padding: "0.5rem", background: "#f3f4f6", borderRadius: "4px", overflow: "auto" }}>
+                  {this.state.error.toString()}
+                </pre>
+              </details>
+            )}
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/dashboard/ComponentComparisonChart.tsx
+++ b/frontend/src/components/dashboard/ComponentComparisonChart.tsx
@@ -2,7 +2,7 @@
  * Component comparison: side-by-side comparison of component means.
  */
 
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Cell } from "recharts";
 import type { NwiSummaryResponse } from "../../types/api";
 import { createComponentData, CHART_MARGINS, CHART_HEIGHTS, NWI_DOMAIN } from "../../lib/chartConfig";
 import { ChartErrorBoundary } from "./ChartErrorBoundary";
@@ -12,25 +12,27 @@ interface ComponentComparisonChartProps {
 }
 
 export function ComponentComparisonChart({ summary }: ComponentComparisonChartProps) {
-  const data = createComponentData(summary)
-    .map((d) => ({
-      name: d.component,
-      label: d.label,
-      value: d.value,
-    }))
-    .filter((d) => d.value != null);
+  const componentData = createComponentData(summary).filter((d) => d.value != null);
 
-  if (data.length === 0) {
+  if (componentData.length === 0) {
     return <p>No component data available.</p>;
   }
 
   // Sort by value descending to show strongest components first
-  const sortedData = [...data].sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+  const sortedData = [...componentData].sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+
+  // Map to chart data format while preserving color
+  const data = sortedData.map((d) => ({
+    name: d.component,
+    label: d.label,
+    value: d.value,
+    color: d.color,
+  }));
 
   return (
     <ChartErrorBoundary chartName="Component Comparison Chart">
       <ResponsiveContainer width="100%" height={CHART_HEIGHTS.compact} aria-label="Bar chart comparing component means sorted by strength">
-        <BarChart data={sortedData} margin={CHART_MARGINS}>
+        <BarChart data={data} margin={CHART_MARGINS}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="name"
@@ -45,12 +47,16 @@ export function ComponentComparisonChart({ summary }: ComponentComparisonChartPr
           <Tooltip
             formatter={(value: number) => value.toFixed(2)}
             labelFormatter={(label: string) => {
-              const item = sortedData.find((d) => d.name === label);
+              const item = data.find((d) => d.name === label);
               return item ? `${item.name}: ${item.label}` : label;
             }}
           />
           <Legend />
-          <Bar dataKey="value" fill="#8884d8" name="Component Mean Score" aria-label="Component mean score" />
+          <Bar dataKey="value" name="Component Mean Score" aria-label="Component mean score">
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.color} />
+            ))}
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
     </ChartErrorBoundary>

--- a/frontend/src/components/dashboard/ComponentComparisonChart.tsx
+++ b/frontend/src/components/dashboard/ComponentComparisonChart.tsx
@@ -1,0 +1,64 @@
+/**
+ * Component comparison: side-by-side comparison of component means.
+ */
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import type { NwiSummaryResponse } from "../../types/api";
+import { COMPONENT_INFO } from "../../lib/componentLabels";
+
+interface ComponentComparisonChartProps {
+  summary: NwiSummaryResponse;
+}
+
+export function ComponentComparisonChart({ summary }: ComponentComparisonChartProps) {
+  const { components } = summary;
+
+  const data = [
+    {
+      name: COMPONENT_INFO.d2a_ranked.code,
+      label: COMPONENT_INFO.d2a_ranked.shortLabel,
+      value: components.employment_housing_mix_rank_mean,
+    },
+    {
+      name: COMPONENT_INFO.d2b_ranked.code,
+      label: COMPONENT_INFO.d2b_ranked.shortLabel,
+      value: components.employment_type_diversity_rank_mean,
+    },
+    {
+      name: COMPONENT_INFO.d3b_ranked.code,
+      label: COMPONENT_INFO.d3b_ranked.shortLabel,
+      value: components.intersection_density_rank_mean,
+    },
+    {
+      name: COMPONENT_INFO.d4a_ranked.code,
+      label: COMPONENT_INFO.d4a_ranked.shortLabel,
+      value: components.transit_proximity_rank_mean_proxy,
+    },
+  ].filter((d) => d.value != null);
+
+  if (data.length === 0) {
+    return <p>No component data available.</p>;
+  }
+
+  // Sort by value descending to show strongest components first
+  const sortedData = [...data].sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={sortedData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" label={{ value: "Component", position: "insideBottom", offset: -5 }} />
+        <YAxis label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }} domain={[0, 20]} />
+        <Tooltip 
+          formatter={(value: number) => value.toFixed(2)} 
+          labelFormatter={(label: string) => {
+            const item = sortedData.find((d) => d.name === label);
+            return item ? `${item.name}: ${item.label}` : label;
+          }}
+        />
+        <Legend />
+        <Bar dataKey="value" fill="#8884d8" name="Component Mean Score" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/dashboard/ComponentComparisonChart.tsx
+++ b/frontend/src/components/dashboard/ComponentComparisonChart.tsx
@@ -4,7 +4,7 @@
 
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { NwiSummaryResponse } from "../../types/api";
-import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { createComponentData, CHART_MARGINS, CHART_HEIGHTS, NWI_DOMAIN } from "../../lib/chartConfig";
 import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentComparisonChartProps {
@@ -12,30 +12,13 @@ interface ComponentComparisonChartProps {
 }
 
 export function ComponentComparisonChart({ summary }: ComponentComparisonChartProps) {
-  const { components } = summary;
-
-  const data = [
-    {
-      name: COMPONENT_INFO.d2a_ranked.code,
-      label: COMPONENT_INFO.d2a_ranked.shortLabel,
-      value: components.employment_housing_mix_rank_mean,
-    },
-    {
-      name: COMPONENT_INFO.d2b_ranked.code,
-      label: COMPONENT_INFO.d2b_ranked.shortLabel,
-      value: components.employment_type_diversity_rank_mean,
-    },
-    {
-      name: COMPONENT_INFO.d3b_ranked.code,
-      label: COMPONENT_INFO.d3b_ranked.shortLabel,
-      value: components.intersection_density_rank_mean,
-    },
-    {
-      name: COMPONENT_INFO.d4a_ranked.code,
-      label: COMPONENT_INFO.d4a_ranked.shortLabel,
-      value: components.transit_proximity_rank_mean_proxy,
-    },
-  ].filter((d) => d.value != null);
+  const data = createComponentData(summary)
+    .map((d) => ({
+      name: d.component,
+      label: d.label,
+      value: d.value,
+    }))
+    .filter((d) => d.value != null);
 
   if (data.length === 0) {
     return <p>No component data available.</p>;
@@ -46,8 +29,8 @@ export function ComponentComparisonChart({ summary }: ComponentComparisonChartPr
 
   return (
     <ChartErrorBoundary chartName="Component Comparison Chart">
-      <ResponsiveContainer width="100%" height={300} aria-label="Bar chart comparing component means sorted by strength">
-        <BarChart data={sortedData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+      <ResponsiveContainer width="100%" height={CHART_HEIGHTS.compact} aria-label="Bar chart comparing component means sorted by strength">
+        <BarChart data={sortedData} margin={CHART_MARGINS}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="name"
@@ -56,7 +39,7 @@ export function ComponentComparisonChart({ summary }: ComponentComparisonChartPr
           />
           <YAxis
             label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }}
-            domain={[0, 20]}
+            domain={NWI_DOMAIN}
             aria-label="Average Score"
           />
           <Tooltip

--- a/frontend/src/components/dashboard/ComponentComparisonChart.tsx
+++ b/frontend/src/components/dashboard/ComponentComparisonChart.tsx
@@ -5,6 +5,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { NwiSummaryResponse } from "../../types/api";
 import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentComparisonChartProps {
   summary: NwiSummaryResponse;
@@ -44,21 +45,31 @@ export function ComponentComparisonChart({ summary }: ComponentComparisonChartPr
   const sortedData = [...data].sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
 
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <BarChart data={sortedData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="name" label={{ value: "Component", position: "insideBottom", offset: -5 }} />
-        <YAxis label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }} domain={[0, 20]} />
-        <Tooltip 
-          formatter={(value: number) => value.toFixed(2)} 
-          labelFormatter={(label: string) => {
-            const item = sortedData.find((d) => d.name === label);
-            return item ? `${item.name}: ${item.label}` : label;
-          }}
-        />
-        <Legend />
-        <Bar dataKey="value" fill="#8884d8" name="Component Mean Score" />
-      </BarChart>
-    </ResponsiveContainer>
+    <ChartErrorBoundary chartName="Component Comparison Chart">
+      <ResponsiveContainer width="100%" height={300} aria-label="Bar chart comparing component means sorted by strength">
+        <BarChart data={sortedData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="name"
+            label={{ value: "Component", position: "insideBottom", offset: -5 }}
+            aria-label="Component"
+          />
+          <YAxis
+            label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }}
+            domain={[0, 20]}
+            aria-label="Average Score"
+          />
+          <Tooltip
+            formatter={(value: number) => value.toFixed(2)}
+            labelFormatter={(label: string) => {
+              const item = sortedData.find((d) => d.name === label);
+              return item ? `${item.name}: ${item.label}` : label;
+            }}
+          />
+          <Legend />
+          <Bar dataKey="value" fill="#8884d8" name="Component Mean Score" aria-label="Component mean score" />
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartErrorBoundary>
   );
 }

--- a/frontend/src/components/dashboard/ComponentContributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentContributionChart.tsx
@@ -2,7 +2,7 @@
  * Component contribution bar chart: shows average component scores vs NWI mean.
  */
 
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from "recharts";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine, Cell } from "recharts";
 import type { NwiSummaryResponse } from "../../types/api";
 import { createComponentData, CHART_MARGINS, CHART_HEIGHTS, NWI_DOMAIN } from "../../lib/chartConfig";
 import { ChartErrorBoundary } from "./ChartErrorBoundary";
@@ -46,7 +46,11 @@ export function ComponentContributionChart({ summary }: ComponentContributionCha
             label={{ value: `NWI Mean: ${nwiMean.toFixed(2)}`, position: "top" }}
             aria-label={`Reference line at NWI mean: ${nwiMean.toFixed(2)}`}
           />
-          <Bar dataKey="value" fill="#8884d8" name="Component Mean" aria-label="Component mean score" />
+          <Bar dataKey="value" name="Component Mean" aria-label="Component mean score">
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.color} />
+            ))}
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
     </ChartErrorBoundary>

--- a/frontend/src/components/dashboard/ComponentContributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentContributionChart.tsx
@@ -4,7 +4,7 @@
 
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from "recharts";
 import type { NwiSummaryResponse } from "../../types/api";
-import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { createComponentData, CHART_MARGINS, CHART_HEIGHTS, NWI_DOMAIN } from "../../lib/chartConfig";
 import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentContributionChartProps {
@@ -12,30 +12,9 @@ interface ComponentContributionChartProps {
 }
 
 export function ComponentContributionChart({ summary }: ComponentContributionChartProps) {
-  const { components, nwi } = summary;
+  const { nwi } = summary;
 
-  const data = [
-    {
-      component: COMPONENT_INFO.d2a_ranked.code,
-      label: COMPONENT_INFO.d2a_ranked.shortLabel,
-      value: components.employment_housing_mix_rank_mean,
-    },
-    {
-      component: COMPONENT_INFO.d2b_ranked.code,
-      label: COMPONENT_INFO.d2b_ranked.shortLabel,
-      value: components.employment_type_diversity_rank_mean,
-    },
-    {
-      component: COMPONENT_INFO.d3b_ranked.code,
-      label: COMPONENT_INFO.d3b_ranked.shortLabel,
-      value: components.intersection_density_rank_mean,
-    },
-    {
-      component: COMPONENT_INFO.d4a_ranked.code,
-      label: COMPONENT_INFO.d4a_ranked.shortLabel,
-      value: components.transit_proximity_rank_mean_proxy,
-    },
-  ].filter((d) => d.value != null);
+  const data = createComponentData(summary).filter((d) => d.value != null);
 
   if (data.length === 0) {
     return <p>No component data available.</p>;
@@ -45,8 +24,8 @@ export function ComponentContributionChart({ summary }: ComponentContributionCha
 
   return (
     <ChartErrorBoundary chartName="Component Contribution Chart">
-      <ResponsiveContainer width="100%" height={300} aria-label="Bar chart comparing component means to NWI average">
-        <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+      <ResponsiveContainer width="100%" height={CHART_HEIGHTS.compact} aria-label="Bar chart comparing component means to NWI average">
+        <BarChart data={data} margin={CHART_MARGINS}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="component"
@@ -55,7 +34,7 @@ export function ComponentContributionChart({ summary }: ComponentContributionCha
           />
           <YAxis
             label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }}
-            domain={[0, 20]}
+            domain={NWI_DOMAIN}
             aria-label="Average Score"
           />
           <Tooltip formatter={(value: number) => value.toFixed(2)} />

--- a/frontend/src/components/dashboard/ComponentContributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentContributionChart.tsx
@@ -1,0 +1,58 @@
+/**
+ * Component contribution bar chart: shows average component scores vs NWI mean.
+ */
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from "recharts";
+import type { NwiSummaryResponse } from "../../types/api";
+import { COMPONENT_INFO } from "../../lib/componentLabels";
+
+interface ComponentContributionChartProps {
+  summary: NwiSummaryResponse;
+}
+
+export function ComponentContributionChart({ summary }: ComponentContributionChartProps) {
+  const { components, nwi } = summary;
+
+  const data = [
+    {
+      component: COMPONENT_INFO.d2a_ranked.code,
+      label: COMPONENT_INFO.d2a_ranked.shortLabel,
+      value: components.employment_housing_mix_rank_mean,
+    },
+    {
+      component: COMPONENT_INFO.d2b_ranked.code,
+      label: COMPONENT_INFO.d2b_ranked.shortLabel,
+      value: components.employment_type_diversity_rank_mean,
+    },
+    {
+      component: COMPONENT_INFO.d3b_ranked.code,
+      label: COMPONENT_INFO.d3b_ranked.shortLabel,
+      value: components.intersection_density_rank_mean,
+    },
+    {
+      component: COMPONENT_INFO.d4a_ranked.code,
+      label: COMPONENT_INFO.d4a_ranked.shortLabel,
+      value: components.transit_proximity_rank_mean_proxy,
+    },
+  ].filter((d) => d.value != null);
+
+  if (data.length === 0) {
+    return <p>No component data available.</p>;
+  }
+
+  const nwiMean = nwi.mean ?? 0;
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="component" label={{ value: "Component", position: "insideBottom", offset: -5 }} />
+        <YAxis label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }} domain={[0, 20]} />
+        <Tooltip formatter={(value: number) => value.toFixed(2)} />
+        <Legend />
+        <ReferenceLine y={nwiMean} stroke="#ff0000" strokeDasharray="3 3" label={{ value: `NWI Mean: ${nwiMean.toFixed(2)}`, position: "top" }} />
+        <Bar dataKey="value" fill="#8884d8" name="Component Mean" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/dashboard/ComponentContributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentContributionChart.tsx
@@ -5,6 +5,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from "recharts";
 import type { NwiSummaryResponse } from "../../types/api";
 import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentContributionChartProps {
   summary: NwiSummaryResponse;
@@ -43,16 +44,32 @@ export function ComponentContributionChart({ summary }: ComponentContributionCha
   const nwiMean = nwi.mean ?? 0;
 
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="component" label={{ value: "Component", position: "insideBottom", offset: -5 }} />
-        <YAxis label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }} domain={[0, 20]} />
-        <Tooltip formatter={(value: number) => value.toFixed(2)} />
-        <Legend />
-        <ReferenceLine y={nwiMean} stroke="#ff0000" strokeDasharray="3 3" label={{ value: `NWI Mean: ${nwiMean.toFixed(2)}`, position: "top" }} />
-        <Bar dataKey="value" fill="#8884d8" name="Component Mean" />
-      </BarChart>
-    </ResponsiveContainer>
+    <ChartErrorBoundary chartName="Component Contribution Chart">
+      <ResponsiveContainer width="100%" height={300} aria-label="Bar chart comparing component means to NWI average">
+        <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="component"
+            label={{ value: "Component", position: "insideBottom", offset: -5 }}
+            aria-label="Component"
+          />
+          <YAxis
+            label={{ value: "Average Score (1-20)", angle: -90, position: "insideLeft" }}
+            domain={[0, 20]}
+            aria-label="Average Score"
+          />
+          <Tooltip formatter={(value: number) => value.toFixed(2)} />
+          <Legend />
+          <ReferenceLine
+            y={nwiMean}
+            stroke="#ff0000"
+            strokeDasharray="3 3"
+            label={{ value: `NWI Mean: ${nwiMean.toFixed(2)}`, position: "top" }}
+            aria-label={`Reference line at NWI mean: ${nwiMean.toFixed(2)}`}
+          />
+          <Bar dataKey="value" fill="#8884d8" name="Component Mean" aria-label="Component mean score" />
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartErrorBoundary>
   );
 }

--- a/frontend/src/components/dashboard/ComponentCorrelationChart.tsx
+++ b/frontend/src/components/dashboard/ComponentCorrelationChart.tsx
@@ -1,16 +1,25 @@
 /**
  * Component correlation scatter plot: shows relationship between components and NWI.
+ * Includes component selector to view one component at a time for clarity.
  */
 
+import { useState } from "react";
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { BlockGroupFeature } from "../../types/api";
 import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentCorrelationChartProps {
   blockGroups: BlockGroupFeature[];
 }
 
+type ComponentKey = "d2a" | "d2b" | "d3b" | "d4a";
+
+const COMPONENT_KEYS: ComponentKey[] = ["d2a", "d2b", "d3b", "d4a"];
+
 export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationChartProps) {
+  const [selectedComponent, setSelectedComponent] = useState<ComponentKey>("d2a");
+
   // Prepare data: component scores vs NWI
   const data = blockGroups
     .filter((bg) => bg.natwalkind != null)
@@ -32,7 +41,7 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
     const pairs = x
       .map((xi, i) => ({ x: xi, y: y[i] }))
       .filter((p) => p.x != null && p.y != null) as { x: number; y: number }[];
-    
+
     if (pairs.length < 2) return 0;
 
     const n = pairs.length;
@@ -44,7 +53,7 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
 
     const numerator = n * sumXY - sumX * sumY;
     const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
-    
+
     return denominator === 0 ? 0 : numerator / denominator;
   }
 
@@ -67,33 +76,91 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
     ),
   };
 
+  const selectedData = data
+    .filter((d) => d[selectedComponent] != null)
+    .map((d) => ({
+      nwi: d.nwi,
+      component: d[selectedComponent]!,
+    }));
+
+  const selectedInfo = COMPONENT_INFO[`${selectedComponent}_ranked` as keyof typeof COMPONENT_INFO];
+  const selectedCorrelation = correlations[selectedComponent];
+
   return (
-    <div className="correlation-charts">
-      <div className="correlation-summary">
-        <h3>Correlation with NWI Score</h3>
-        <p style={{ margin: "0 0 0.75rem 0", fontSize: "0.9rem", color: "#6b7280" }}>
-          Values range from -1 (negative correlation) to +1 (positive correlation). Higher positive values indicate stronger relationship with overall walkability.
-        </p>
-        <ul>
-          <li>{COMPONENT_INFO.d2a_ranked.code} ({COMPONENT_INFO.d2a_ranked.shortLabel}): <strong>{correlations.d2a.toFixed(3)}</strong></li>
-          <li>{COMPONENT_INFO.d2b_ranked.code} ({COMPONENT_INFO.d2b_ranked.shortLabel}): <strong>{correlations.d2b.toFixed(3)}</strong></li>
-          <li>{COMPONENT_INFO.d3b_ranked.code} ({COMPONENT_INFO.d3b_ranked.shortLabel}): <strong>{correlations.d3b.toFixed(3)}</strong></li>
-          <li>{COMPONENT_INFO.d4a_ranked.code} ({COMPONENT_INFO.d4a_ranked.shortLabel}): <strong>{correlations.d4a.toFixed(3)}</strong></li>
-        </ul>
+    <ChartErrorBoundary chartName="Component Correlation Chart">
+      <div className="correlation-charts">
+        <div className="correlation-summary">
+          <h3>Correlation with NWI Score</h3>
+          <p style={{ margin: "0 0 0.75rem 0", fontSize: "0.9rem", color: "#6b7280" }}>
+            Values range from -1 (negative correlation) to +1 (positive correlation). Higher positive values indicate stronger relationship with overall walkability.
+          </p>
+          <div className="correlation-component-selector" role="group" aria-label="Select component to view correlation">
+            {COMPONENT_KEYS.map((key) => {
+              const info = COMPONENT_INFO[`${key}_ranked` as keyof typeof COMPONENT_INFO];
+              const isSelected = selectedComponent === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setSelectedComponent(key)}
+                  className={`correlation-selector-btn ${isSelected ? "correlation-selector-btn--active" : ""}`}
+                  aria-pressed={isSelected}
+                  aria-label={`View correlation for ${info.shortLabel}`}
+                >
+                  <span className="correlation-selector-code">{info.code}</span>
+                  <span className="correlation-selector-label">{info.shortLabel}</span>
+                  <span className="correlation-selector-value">{correlations[key].toFixed(3)}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="correlation-chart-container" aria-label={`Scatter plot showing ${selectedInfo.shortLabel} vs NWI Score`}>
+          <ResponsiveContainer width="100%" height={400}>
+            <ScatterChart margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                type="number"
+                dataKey="nwi"
+                name="NWI Score"
+                label={{ value: "NWI Score", position: "insideBottom", offset: -5 }}
+                domain={[0, 20]}
+                aria-label="NWI Score axis"
+              />
+              <YAxis
+                type="number"
+                dataKey="component"
+                name="Component Score"
+                label={{ value: `${selectedInfo.code} Score`, angle: -90, position: "insideLeft" }}
+                domain={[0, 20]}
+                aria-label={`${selectedInfo.shortLabel} Score axis`}
+              />
+              <Tooltip
+                cursor={{ strokeDasharray: "3 3" }}
+                formatter={(value: number) => value.toFixed(2)}
+                labelFormatter={(label: string) => `NWI: ${label}`}
+              />
+              <Legend />
+              <Scatter
+                name={`${selectedInfo.code}: ${selectedInfo.shortLabel}`}
+                data={selectedData}
+                fill={
+                  selectedComponent === "d2a"
+                    ? "#8884d8"
+                    : selectedComponent === "d2b"
+                      ? "#82ca9d"
+                      : selectedComponent === "d3b"
+                        ? "#ffc658"
+                        : "#ff7300"
+                }
+              />
+            </ScatterChart>
+          </ResponsiveContainer>
+          <p className="correlation-chart-note" style={{ marginTop: "0.5rem", fontSize: "0.85rem", color: "#6b7280", textAlign: "center" }}>
+            Correlation coefficient: <strong>{selectedCorrelation.toFixed(3)}</strong>
+          </p>
+        </div>
       </div>
-      <ResponsiveContainer width="100%" height={400}>
-        <ScatterChart margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis type="number" dataKey="nwi" name="NWI Score" label={{ value: "NWI Score", position: "insideBottom", offset: -5 }} domain={[0, 20]} />
-          <YAxis type="number" dataKey="component" name="Component Score" label={{ value: "Component Score", angle: -90, position: "insideLeft" }} domain={[0, 20]} />
-          <Tooltip cursor={{ strokeDasharray: "3 3" }} formatter={(value: number) => value.toFixed(2)} />
-          <Legend />
-          <Scatter name={`${COMPONENT_INFO.d2a_ranked.code}: ${COMPONENT_INFO.d2a_ranked.shortLabel}`} data={data.filter((d) => d.d2a != null).map((d) => ({ nwi: d.nwi, component: d.d2a! }))} fill="#8884d8" />
-          <Scatter name={`${COMPONENT_INFO.d2b_ranked.code}: ${COMPONENT_INFO.d2b_ranked.shortLabel}`} data={data.filter((d) => d.d2b != null).map((d) => ({ nwi: d.nwi, component: d.d2b! }))} fill="#82ca9d" />
-          <Scatter name={`${COMPONENT_INFO.d3b_ranked.code}: ${COMPONENT_INFO.d3b_ranked.shortLabel}`} data={data.filter((d) => d.d3b != null).map((d) => ({ nwi: d.nwi, component: d.d3b! }))} fill="#ffc658" />
-          <Scatter name={`${COMPONENT_INFO.d4a_ranked.code}: ${COMPONENT_INFO.d4a_ranked.shortLabel}`} data={data.filter((d) => d.d4a != null).map((d) => ({ nwi: d.nwi, component: d.d4a! }))} fill="#ff7300" />
-        </ScatterChart>
-      </ResponsiveContainer>
-    </div>
+    </ChartErrorBoundary>
   );
 }

--- a/frontend/src/components/dashboard/ComponentCorrelationChart.tsx
+++ b/frontend/src/components/dashboard/ComponentCorrelationChart.tsx
@@ -7,6 +7,8 @@ import { useState } from "react";
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { BlockGroupFeature } from "../../types/api";
 import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { CHART_MARGINS, CHART_HEIGHTS, NWI_DOMAIN, getComponentColor } from "../../lib/chartConfig";
+import { calculateCorrelation } from "../../lib/correlation";
 import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentCorrelationChartProps {
@@ -34,27 +36,6 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
 
   if (data.length === 0) {
     return <p>No data available for correlation analysis.</p>;
-  }
-
-  // Calculate correlation coefficient (simple Pearson correlation)
-  function calculateCorrelation(x: (number | null)[], y: (number | null)[]): number {
-    const pairs = x
-      .map((xi, i) => ({ x: xi, y: y[i] }))
-      .filter((p) => p.x != null && p.y != null) as { x: number; y: number }[];
-
-    if (pairs.length < 2) return 0;
-
-    const n = pairs.length;
-    const sumX = pairs.reduce((sum, p) => sum + p.x, 0);
-    const sumY = pairs.reduce((sum, p) => sum + p.y, 0);
-    const sumXY = pairs.reduce((sum, p) => sum + p.x * p.y, 0);
-    const sumX2 = pairs.reduce((sum, p) => sum + p.x * p.x, 0);
-    const sumY2 = pairs.reduce((sum, p) => sum + p.y * p.y, 0);
-
-    const numerator = n * sumXY - sumX * sumY;
-    const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
-
-    return denominator === 0 ? 0 : numerator / denominator;
   }
 
   const correlations = {
@@ -116,15 +97,15 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
           </div>
         </div>
         <div className="correlation-chart-container" aria-label={`Scatter plot showing ${selectedInfo.shortLabel} vs NWI Score`}>
-          <ResponsiveContainer width="100%" height={400}>
-            <ScatterChart margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <ResponsiveContainer width="100%" height={CHART_HEIGHTS.standard}>
+            <ScatterChart margin={CHART_MARGINS}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis
                 type="number"
                 dataKey="nwi"
                 name="NWI Score"
                 label={{ value: "NWI Score", position: "insideBottom", offset: -5 }}
-                domain={[0, 20]}
+                domain={NWI_DOMAIN}
                 aria-label="NWI Score axis"
               />
               <YAxis
@@ -132,7 +113,7 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
                 dataKey="component"
                 name="Component Score"
                 label={{ value: `${selectedInfo.code} Score`, angle: -90, position: "insideLeft" }}
-                domain={[0, 20]}
+                domain={NWI_DOMAIN}
                 aria-label={`${selectedInfo.shortLabel} Score axis`}
               />
               <Tooltip
@@ -144,15 +125,7 @@ export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationC
               <Scatter
                 name={`${selectedInfo.code}: ${selectedInfo.shortLabel}`}
                 data={selectedData}
-                fill={
-                  selectedComponent === "d2a"
-                    ? "#8884d8"
-                    : selectedComponent === "d2b"
-                      ? "#82ca9d"
-                      : selectedComponent === "d3b"
-                        ? "#ffc658"
-                        : "#ff7300"
-                }
+                fill={getComponentColor(selectedComponent)}
               />
             </ScatterChart>
           </ResponsiveContainer>

--- a/frontend/src/components/dashboard/ComponentCorrelationChart.tsx
+++ b/frontend/src/components/dashboard/ComponentCorrelationChart.tsx
@@ -1,0 +1,99 @@
+/**
+ * Component correlation scatter plot: shows relationship between components and NWI.
+ */
+
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import type { BlockGroupFeature } from "../../types/api";
+import { COMPONENT_INFO } from "../../lib/componentLabels";
+
+interface ComponentCorrelationChartProps {
+  blockGroups: BlockGroupFeature[];
+}
+
+export function ComponentCorrelationChart({ blockGroups }: ComponentCorrelationChartProps) {
+  // Prepare data: component scores vs NWI
+  const data = blockGroups
+    .filter((bg) => bg.natwalkind != null)
+    .map((bg) => ({
+      nwi: bg.natwalkind!,
+      d2a: bg.d2a_ranked,
+      d2b: bg.d2b_ranked,
+      d3b: bg.d3b_ranked,
+      d4a: bg.d4a_ranked,
+    }))
+    .filter((d) => d.d2a != null || d.d2b != null || d.d3b != null || d.d4a != null);
+
+  if (data.length === 0) {
+    return <p>No data available for correlation analysis.</p>;
+  }
+
+  // Calculate correlation coefficient (simple Pearson correlation)
+  function calculateCorrelation(x: (number | null)[], y: (number | null)[]): number {
+    const pairs = x
+      .map((xi, i) => ({ x: xi, y: y[i] }))
+      .filter((p) => p.x != null && p.y != null) as { x: number; y: number }[];
+    
+    if (pairs.length < 2) return 0;
+
+    const n = pairs.length;
+    const sumX = pairs.reduce((sum, p) => sum + p.x, 0);
+    const sumY = pairs.reduce((sum, p) => sum + p.y, 0);
+    const sumXY = pairs.reduce((sum, p) => sum + p.x * p.y, 0);
+    const sumX2 = pairs.reduce((sum, p) => sum + p.x * p.x, 0);
+    const sumY2 = pairs.reduce((sum, p) => sum + p.y * p.y, 0);
+
+    const numerator = n * sumXY - sumX * sumY;
+    const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+    
+    return denominator === 0 ? 0 : numerator / denominator;
+  }
+
+  const correlations = {
+    d2a: calculateCorrelation(
+      data.map((d) => d.d2a),
+      data.map((d) => d.nwi)
+    ),
+    d2b: calculateCorrelation(
+      data.map((d) => d.d2b),
+      data.map((d) => d.nwi)
+    ),
+    d3b: calculateCorrelation(
+      data.map((d) => d.d3b),
+      data.map((d) => d.nwi)
+    ),
+    d4a: calculateCorrelation(
+      data.map((d) => d.d4a),
+      data.map((d) => d.nwi)
+    ),
+  };
+
+  return (
+    <div className="correlation-charts">
+      <div className="correlation-summary">
+        <h3>Correlation with NWI Score</h3>
+        <p style={{ margin: "0 0 0.75rem 0", fontSize: "0.9rem", color: "#6b7280" }}>
+          Values range from -1 (negative correlation) to +1 (positive correlation). Higher positive values indicate stronger relationship with overall walkability.
+        </p>
+        <ul>
+          <li>{COMPONENT_INFO.d2a_ranked.code} ({COMPONENT_INFO.d2a_ranked.shortLabel}): <strong>{correlations.d2a.toFixed(3)}</strong></li>
+          <li>{COMPONENT_INFO.d2b_ranked.code} ({COMPONENT_INFO.d2b_ranked.shortLabel}): <strong>{correlations.d2b.toFixed(3)}</strong></li>
+          <li>{COMPONENT_INFO.d3b_ranked.code} ({COMPONENT_INFO.d3b_ranked.shortLabel}): <strong>{correlations.d3b.toFixed(3)}</strong></li>
+          <li>{COMPONENT_INFO.d4a_ranked.code} ({COMPONENT_INFO.d4a_ranked.shortLabel}): <strong>{correlations.d4a.toFixed(3)}</strong></li>
+        </ul>
+      </div>
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" dataKey="nwi" name="NWI Score" label={{ value: "NWI Score", position: "insideBottom", offset: -5 }} domain={[0, 20]} />
+          <YAxis type="number" dataKey="component" name="Component Score" label={{ value: "Component Score", angle: -90, position: "insideLeft" }} domain={[0, 20]} />
+          <Tooltip cursor={{ strokeDasharray: "3 3" }} formatter={(value: number) => value.toFixed(2)} />
+          <Legend />
+          <Scatter name={`${COMPONENT_INFO.d2a_ranked.code}: ${COMPONENT_INFO.d2a_ranked.shortLabel}`} data={data.filter((d) => d.d2a != null).map((d) => ({ nwi: d.nwi, component: d.d2a! }))} fill="#8884d8" />
+          <Scatter name={`${COMPONENT_INFO.d2b_ranked.code}: ${COMPONENT_INFO.d2b_ranked.shortLabel}`} data={data.filter((d) => d.d2b != null).map((d) => ({ nwi: d.nwi, component: d.d2b! }))} fill="#82ca9d" />
+          <Scatter name={`${COMPONENT_INFO.d3b_ranked.code}: ${COMPONENT_INFO.d3b_ranked.shortLabel}`} data={data.filter((d) => d.d3b != null).map((d) => ({ nwi: d.nwi, component: d.d3b! }))} fill="#ffc658" />
+          <Scatter name={`${COMPONENT_INFO.d4a_ranked.code}: ${COMPONENT_INFO.d4a_ranked.shortLabel}`} data={data.filter((d) => d.d4a != null).map((d) => ({ nwi: d.nwi, component: d.d4a! }))} fill="#ff7300" />
+        </ScatterChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/ComponentDistributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentDistributionChart.tsx
@@ -5,6 +5,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { BlockGroupFeature } from "../../types/api";
 import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { COMPONENT_COLORS, CHART_MARGINS, CHART_HEIGHTS, NWI_DOMAIN } from "../../lib/chartConfig";
 import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentDistributionChartProps {
@@ -38,13 +39,14 @@ export function ComponentDistributionChart({ blockGroups }: ComponentDistributio
 
   return (
     <ChartErrorBoundary chartName="Component Distribution Chart">
-      <ResponsiveContainer width="100%" height={400} aria-label="Histogram showing distribution of component scores across block groups">
-        <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+      <ResponsiveContainer width="100%" height={CHART_HEIGHTS.standard} aria-label="Histogram showing distribution of component scores across block groups">
+        <BarChart data={data} margin={CHART_MARGINS}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
             dataKey="score"
             label={{ value: "Component Score (1-20)", position: "insideBottom", offset: -5 }}
             aria-label="Component Score"
+            domain={NWI_DOMAIN}
           />
           <YAxis
             label={{ value: "Number of Block Groups", angle: -90, position: "insideLeft" }}
@@ -54,25 +56,25 @@ export function ComponentDistributionChart({ blockGroups }: ComponentDistributio
           <Legend />
           <Bar
             dataKey="d2a"
-            fill="#8884d8"
+            fill={COMPONENT_COLORS.d2a}
             name={`${COMPONENT_INFO.d2a_ranked.code}: ${COMPONENT_INFO.d2a_ranked.shortLabel}`}
             aria-label={`${COMPONENT_INFO.d2a_ranked.shortLabel} distribution`}
           />
           <Bar
             dataKey="d2b"
-            fill="#82ca9d"
+            fill={COMPONENT_COLORS.d2b}
             name={`${COMPONENT_INFO.d2b_ranked.code}: ${COMPONENT_INFO.d2b_ranked.shortLabel}`}
             aria-label={`${COMPONENT_INFO.d2b_ranked.shortLabel} distribution`}
           />
           <Bar
             dataKey="d3b"
-            fill="#ffc658"
+            fill={COMPONENT_COLORS.d3b}
             name={`${COMPONENT_INFO.d3b_ranked.code}: ${COMPONENT_INFO.d3b_ranked.shortLabel}`}
             aria-label={`${COMPONENT_INFO.d3b_ranked.shortLabel} distribution`}
           />
           <Bar
             dataKey="d4a"
-            fill="#ff7300"
+            fill={COMPONENT_COLORS.d4a}
             name={`${COMPONENT_INFO.d4a_ranked.code}: ${COMPONENT_INFO.d4a_ranked.shortLabel}`}
             aria-label={`${COMPONENT_INFO.d4a_ranked.shortLabel} distribution`}
           />

--- a/frontend/src/components/dashboard/ComponentDistributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentDistributionChart.tsx
@@ -1,0 +1,53 @@
+/**
+ * Component distribution histogram: shows distribution of each component score (1-20).
+ */
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import type { BlockGroupFeature } from "../../types/api";
+import { COMPONENT_INFO } from "../../lib/componentLabels";
+
+interface ComponentDistributionChartProps {
+  blockGroups: BlockGroupFeature[];
+}
+
+export function ComponentDistributionChart({ blockGroups }: ComponentDistributionChartProps) {
+  // Create histogram bins (1-20)
+  const bins = Array.from({ length: 20 }, (_, i) => ({ score: i + 1 }));
+  
+  // Count occurrences for each component
+  const d2aCounts = new Map<number, number>();
+  const d2bCounts = new Map<number, number>();
+  const d3bCounts = new Map<number, number>();
+  const d4aCounts = new Map<number, number>();
+
+  blockGroups.forEach((bg) => {
+    if (bg.d2a_ranked != null) d2aCounts.set(bg.d2a_ranked, (d2aCounts.get(bg.d2a_ranked) || 0) + 1);
+    if (bg.d2b_ranked != null) d2bCounts.set(bg.d2b_ranked, (d2bCounts.get(bg.d2b_ranked) || 0) + 1);
+    if (bg.d3b_ranked != null) d3bCounts.set(bg.d3b_ranked, (d3bCounts.get(bg.d3b_ranked) || 0) + 1);
+    if (bg.d4a_ranked != null) d4aCounts.set(bg.d4a_ranked, (d4aCounts.get(bg.d4a_ranked) || 0) + 1);
+  });
+
+  const data = bins.map((bin) => ({
+    score: bin.score,
+    d2a: d2aCounts.get(bin.score) || 0,
+    d2b: d2bCounts.get(bin.score) || 0,
+    d3b: d3bCounts.get(bin.score) || 0,
+    d4a: d4aCounts.get(bin.score) || 0,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={400}>
+      <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="score" label={{ value: "Component Score (1-20)", position: "insideBottom", offset: -5 }} />
+        <YAxis label={{ value: "Number of Block Groups", angle: -90, position: "insideLeft" }} />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="d2a" fill="#8884d8" name={`${COMPONENT_INFO.d2a_ranked.code}: ${COMPONENT_INFO.d2a_ranked.shortLabel}`} />
+        <Bar dataKey="d2b" fill="#82ca9d" name={`${COMPONENT_INFO.d2b_ranked.code}: ${COMPONENT_INFO.d2b_ranked.shortLabel}`} />
+        <Bar dataKey="d3b" fill="#ffc658" name={`${COMPONENT_INFO.d3b_ranked.code}: ${COMPONENT_INFO.d3b_ranked.shortLabel}`} />
+        <Bar dataKey="d4a" fill="#ff7300" name={`${COMPONENT_INFO.d4a_ranked.code}: ${COMPONENT_INFO.d4a_ranked.shortLabel}`} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/dashboard/ComponentDistributionChart.tsx
+++ b/frontend/src/components/dashboard/ComponentDistributionChart.tsx
@@ -5,6 +5,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import type { BlockGroupFeature } from "../../types/api";
 import { COMPONENT_INFO } from "../../lib/componentLabels";
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
 
 interface ComponentDistributionChartProps {
   blockGroups: BlockGroupFeature[];
@@ -36,18 +37,47 @@ export function ComponentDistributionChart({ blockGroups }: ComponentDistributio
   }));
 
   return (
-    <ResponsiveContainer width="100%" height={400}>
-      <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="score" label={{ value: "Component Score (1-20)", position: "insideBottom", offset: -5 }} />
-        <YAxis label={{ value: "Number of Block Groups", angle: -90, position: "insideLeft" }} />
-        <Tooltip />
-        <Legend />
-        <Bar dataKey="d2a" fill="#8884d8" name={`${COMPONENT_INFO.d2a_ranked.code}: ${COMPONENT_INFO.d2a_ranked.shortLabel}`} />
-        <Bar dataKey="d2b" fill="#82ca9d" name={`${COMPONENT_INFO.d2b_ranked.code}: ${COMPONENT_INFO.d2b_ranked.shortLabel}`} />
-        <Bar dataKey="d3b" fill="#ffc658" name={`${COMPONENT_INFO.d3b_ranked.code}: ${COMPONENT_INFO.d3b_ranked.shortLabel}`} />
-        <Bar dataKey="d4a" fill="#ff7300" name={`${COMPONENT_INFO.d4a_ranked.code}: ${COMPONENT_INFO.d4a_ranked.shortLabel}`} />
-      </BarChart>
-    </ResponsiveContainer>
+    <ChartErrorBoundary chartName="Component Distribution Chart">
+      <ResponsiveContainer width="100%" height={400} aria-label="Histogram showing distribution of component scores across block groups">
+        <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="score"
+            label={{ value: "Component Score (1-20)", position: "insideBottom", offset: -5 }}
+            aria-label="Component Score"
+          />
+          <YAxis
+            label={{ value: "Number of Block Groups", angle: -90, position: "insideLeft" }}
+            aria-label="Number of Block Groups"
+          />
+          <Tooltip />
+          <Legend />
+          <Bar
+            dataKey="d2a"
+            fill="#8884d8"
+            name={`${COMPONENT_INFO.d2a_ranked.code}: ${COMPONENT_INFO.d2a_ranked.shortLabel}`}
+            aria-label={`${COMPONENT_INFO.d2a_ranked.shortLabel} distribution`}
+          />
+          <Bar
+            dataKey="d2b"
+            fill="#82ca9d"
+            name={`${COMPONENT_INFO.d2b_ranked.code}: ${COMPONENT_INFO.d2b_ranked.shortLabel}`}
+            aria-label={`${COMPONENT_INFO.d2b_ranked.shortLabel} distribution`}
+          />
+          <Bar
+            dataKey="d3b"
+            fill="#ffc658"
+            name={`${COMPONENT_INFO.d3b_ranked.code}: ${COMPONENT_INFO.d3b_ranked.shortLabel}`}
+            aria-label={`${COMPONENT_INFO.d3b_ranked.shortLabel} distribution`}
+          />
+          <Bar
+            dataKey="d4a"
+            fill="#ff7300"
+            name={`${COMPONENT_INFO.d4a_ranked.code}: ${COMPONENT_INFO.d4a_ranked.shortLabel}`}
+            aria-label={`${COMPONENT_INFO.d4a_ranked.shortLabel} distribution`}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartErrorBoundary>
   );
 }

--- a/frontend/src/lib/chartConfig.ts
+++ b/frontend/src/lib/chartConfig.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared configuration for dashboard charts.
+ * Centralizes chart styling, colors, and common settings.
+ */
+
+import { COMPONENT_INFO } from "./componentLabels";
+
+/**
+ * Component color scheme for consistent visualization across charts.
+ * Colors chosen for accessibility and visual distinction.
+ */
+export const COMPONENT_COLORS = {
+  d2a: "#8884d8", // Purple - Employment and Household Mix
+  d2b: "#82ca9d", // Green - Employment Mix
+  d3b: "#ffc658", // Yellow - Intersection Density
+  d4a: "#ff7300", // Orange - Transit Proximity
+} as const;
+
+/**
+ * Get color for a component by its key.
+ */
+export function getComponentColor(componentKey: "d2a" | "d2b" | "d3b" | "d4a"): string {
+  return COMPONENT_COLORS[componentKey];
+}
+
+/**
+ * Common chart margin configuration.
+ */
+export const CHART_MARGINS = {
+  top: 20,
+  right: 30,
+  left: 20,
+  bottom: 5,
+} as const;
+
+/**
+ * NWI score domain (1-20 scale).
+ */
+export const NWI_DOMAIN = [0, 20] as const;
+
+/**
+ * Common chart height configurations.
+ */
+export const CHART_HEIGHTS = {
+  standard: 400,
+  compact: 300,
+} as const;
+
+/**
+ * Helper to create component data array for charts.
+ * Ensures consistent ordering and structure.
+ */
+export function createComponentData(summary: {
+  components: {
+    employment_housing_mix_rank_mean: number | null;
+    employment_type_diversity_rank_mean: number | null;
+    intersection_density_rank_mean: number | null;
+    transit_proximity_rank_mean_proxy: number | null;
+  };
+}) {
+  return [
+    {
+      key: "d2a" as const,
+      component: COMPONENT_INFO.d2a_ranked.code,
+      label: COMPONENT_INFO.d2a_ranked.shortLabel,
+      value: summary.components.employment_housing_mix_rank_mean,
+      color: COMPONENT_COLORS.d2a,
+    },
+    {
+      key: "d2b" as const,
+      component: COMPONENT_INFO.d2b_ranked.code,
+      label: COMPONENT_INFO.d2b_ranked.shortLabel,
+      value: summary.components.employment_type_diversity_rank_mean,
+      color: COMPONENT_COLORS.d2b,
+    },
+    {
+      key: "d3b" as const,
+      component: COMPONENT_INFO.d3b_ranked.code,
+      label: COMPONENT_INFO.d3b_ranked.shortLabel,
+      value: summary.components.intersection_density_rank_mean,
+      color: COMPONENT_COLORS.d3b,
+    },
+    {
+      key: "d4a" as const,
+      component: COMPONENT_INFO.d4a_ranked.code,
+      label: COMPONENT_INFO.d4a_ranked.shortLabel,
+      value: summary.components.transit_proximity_rank_mean_proxy,
+      color: COMPONENT_COLORS.d4a,
+    },
+  ];
+}

--- a/frontend/src/lib/componentLabels.ts
+++ b/frontend/src/lib/componentLabels.ts
@@ -1,0 +1,48 @@
+/**
+ * Component labels and descriptions for NWI components.
+ * Based on EPA National Walkability Index methodology.
+ */
+
+export interface ComponentInfo {
+  code: string;
+  shortLabel: string;
+  fullLabel: string;
+  description: string;
+}
+
+export const COMPONENT_INFO: Record<string, ComponentInfo> = {
+  d2a_ranked: {
+    code: "D2A",
+    shortLabel: "Employment & Household Mix",
+    fullLabel: "Employment and Household Mix",
+    description: "The mix of employment types and occupied housing. A block group with diverse employment types (office, retail, service) plus many occupied housing units will have a higher score.",
+  },
+  d2b_ranked: {
+    code: "D2B",
+    shortLabel: "Employment Mix",
+    fullLabel: "Employment Type Diversity",
+    description: "The mix of employment types in a block group (retail, office, industrial). Higher values indicate greater diversity of employment types.",
+  },
+  d3b_ranked: {
+    code: "D3B",
+    shortLabel: "Intersection Density",
+    fullLabel: "Street Intersection Density",
+    description: "The density of street intersections. Higher intersection density is correlated with more walk trips and better street connectivity.",
+  },
+  d4a_ranked: {
+    code: "D4A",
+    shortLabel: "Transit Proximity",
+    fullLabel: "Proximity to Transit Stops",
+    description: "Distance from population center to nearest transit stop. Shorter distances (higher scores) correlate with more walk trips.",
+  },
+};
+
+export function getComponentInfo(componentKey: string): ComponentInfo | undefined {
+  return COMPONENT_INFO[componentKey];
+}
+
+export function getComponentLabel(componentKey: string, useFull = false): string {
+  const info = COMPONENT_INFO[componentKey];
+  if (!info) return componentKey;
+  return useFull ? info.fullLabel : info.shortLabel;
+}

--- a/frontend/src/lib/componentLabels.ts
+++ b/frontend/src/lib/componentLabels.ts
@@ -36,13 +36,3 @@ export const COMPONENT_INFO: Record<string, ComponentInfo> = {
     description: "Distance from population center to nearest transit stop. Shorter distances (higher scores) correlate with more walk trips.",
   },
 };
-
-export function getComponentInfo(componentKey: string): ComponentInfo | undefined {
-  return COMPONENT_INFO[componentKey];
-}
-
-export function getComponentLabel(componentKey: string, useFull = false): string {
-  const info = COMPONENT_INFO[componentKey];
-  if (!info) return componentKey;
-  return useFull ? info.fullLabel : info.shortLabel;
-}

--- a/frontend/src/lib/correlation.ts
+++ b/frontend/src/lib/correlation.ts
@@ -1,0 +1,31 @@
+/**
+ * Correlation calculation utilities for component analysis.
+ */
+
+/**
+ * Calculate Pearson correlation coefficient between two arrays.
+ * Handles null values by filtering them out before calculation.
+ *
+ * @param x First variable array (may contain nulls)
+ * @param y Second variable array (may contain nulls)
+ * @returns Correlation coefficient (-1 to 1), or 0 if insufficient data
+ */
+export function calculateCorrelation(x: (number | null)[], y: (number | null)[]): number {
+  const pairs = x
+    .map((xi, i) => ({ x: xi, y: y[i] }))
+    .filter((p) => p.x != null && p.y != null) as { x: number; y: number }[];
+
+  if (pairs.length < 2) return 0;
+
+  const n = pairs.length;
+  const sumX = pairs.reduce((sum, p) => sum + p.x, 0);
+  const sumY = pairs.reduce((sum, p) => sum + p.y, 0);
+  const sumXY = pairs.reduce((sum, p) => sum + p.x * p.y, 0);
+  const sumX2 = pairs.reduce((sum, p) => sum + p.x * p.x, 0);
+  const sumY2 = pairs.reduce((sum, p) => sum + p.y * p.y, 0);
+
+  const numerator = n * sumXY - sumX * sumY;
+  const denominator = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+
+  return denominator === 0 ? 0 : numerator / denominator;
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,156 @@
+/**
+ * Dashboard page: component analysis visualizations.
+ * URL query params (q, radius) for shareability; reuses Explore params structure.
+ */
+
+import { nwiSummaryByQuery } from "../api/client";
+import type { NwiSummaryResponse } from "../types/api";
+import {
+  EXPLORE_PARAMS,
+  parseExploreParams,
+  buildExploreSearchParams,
+  canFetch,
+  canonicalRadius,
+  type ExploreParams,
+} from "../lib/exploreParams";
+import { useUrlDrivenSearch } from "../hooks/useUrlDrivenSearch";
+import { ComponentDistributionChart } from "../components/dashboard/ComponentDistributionChart";
+import { ComponentCorrelationChart } from "../components/dashboard/ComponentCorrelationChart";
+import { ComponentContributionChart } from "../components/dashboard/ComponentContributionChart";
+import { ComponentComparisonChart } from "../components/dashboard/ComponentComparisonChart";
+
+const { MIN_RADIUS, MAX_RADIUS, STEP } = EXPLORE_PARAMS;
+
+export function Dashboard() {
+  const {
+    params,
+    result: summary,
+    loading,
+    error,
+    validationMessage: paramValidationMessage,
+    updateDraft,
+    submit,
+  } = useUrlDrivenSearch<ExploreParams, NwiSummaryResponse>({
+    parse: parseExploreParams,
+    build: buildExploreSearchParams,
+    canFetch,
+    fetch: (p, signal) => nwiSummaryByQuery(p.q, p.radius, { signal }),
+    emptyFetchMessage: "Enter a location to analyze components.",
+    trimParams: (p) => ({ ...p, q: p.q.trim() }),
+  });
+
+  function handleQueryChange(value: string) {
+    updateDraft({
+      q: value.slice(0, EXPLORE_PARAMS.MAX_QUERY_LENGTH),
+      radius: canonicalRadius(params.radius),
+    });
+  }
+
+  function handleRadiusChange(value: number) {
+    const r = canonicalRadius(value);
+    updateDraft({ q: params.q, radius: r });
+  }
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    submit();
+  }
+
+  const hasData = summary && summary.block_groups.length > 0;
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard__header">
+        <h1>Component Analysis Dashboard</h1>
+        <p className="dashboard__tagline">
+          Deep dive into the four components that make up the National Walkability Index.
+        </p>
+      </header>
+
+      <div className="dashboard__body">
+        <section className="dashboard__controls">
+          <form onSubmit={handleSearch} className="dashboard__form">
+            <label htmlFor="search">Address, ZIP, or city</label>
+            <input
+              id="search"
+              type="text"
+              value={params.q}
+              onChange={(e) => handleQueryChange(e.target.value)}
+              placeholder="e.g. Cambridge, MA"
+              disabled={loading}
+              autoComplete="off"
+            />
+            <div className="dashboard__radius">
+              <label htmlFor="radius">Radius (miles): {params.radius.toFixed(1)}</label>
+              <input
+                id="radius"
+                type="range"
+                min={MIN_RADIUS}
+                max={MAX_RADIUS}
+                step={STEP}
+                value={params.radius}
+                onChange={(e) => handleRadiusChange(Number(e.target.value))}
+                disabled={loading}
+              />
+            </div>
+            <button type="submit" disabled={loading}>
+              {loading ? "Loading…" : "Analyze"}
+            </button>
+          </form>
+        </section>
+
+        {(paramValidationMessage || error) && (
+          <div className="dashboard__error" role="alert">
+            {paramValidationMessage ?? error}
+          </div>
+        )}
+
+        {!hasData && !loading && (
+          <div className="dashboard__empty">
+            <p>Enter a location to view component analysis.</p>
+            <p className="dashboard__empty-hint">
+              The dashboard shows distributions, correlations, and contributions of the four NWI components:
+              Employment and Household Mix (D2A), Employment Mix (D2B), Street Intersection Density (D3B), and Proximity to Transit Stops (D4A).
+            </p>
+          </div>
+        )}
+
+        {hasData && (
+          <div className="dashboard__visualizations">
+            <section className="dashboard__section">
+              <h2>Component Distributions</h2>
+              <p className="dashboard__section-description">
+                Distribution of component scores (1-20) across block groups in the selected area.
+              </p>
+              <ComponentDistributionChart blockGroups={summary.block_groups} />
+            </section>
+
+            <section className="dashboard__section">
+              <h2>Component Correlations</h2>
+              <p className="dashboard__section-description">
+                How component scores relate to each other and to the overall NWI score.
+              </p>
+              <ComponentCorrelationChart blockGroups={summary.block_groups} />
+            </section>
+
+            <section className="dashboard__section">
+              <h2>Component Contribution</h2>
+              <p className="dashboard__section-description">
+                Average component scores compared to the overall NWI mean. Components are ranked 1-20, where higher values indicate better walkability.
+              </p>
+              <ComponentContributionChart summary={summary} />
+            </section>
+
+            <section className="dashboard__section">
+              <h2>Component Comparison</h2>
+              <p className="dashboard__section-description">
+                Side-by-side comparison of component means, showing which dimensions drive walkability in this area.
+              </p>
+              <ComponentComparisonChart summary={summary} />
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -105,7 +105,7 @@ export function Dashboard() {
           </div>
         )}
 
-        {!hasData && !loading && (
+        {!hasData && !loading && !error && !paramValidationMessage && (
           <div className="dashboard__empty">
             <p>Enter a location to view component analysis.</p>
             <p className="dashboard__empty-hint">

--- a/frontend/src/pages/Method.tsx
+++ b/frontend/src/pages/Method.tsx
@@ -47,16 +47,20 @@ export function Method() {
             the four components; higher means more walkable.
           </li>
           <li>
-            <strong>D2A (destinations)</strong> — Proximity to common destinations (e.g. retail, services).
+            <strong>D2A: Employment and Household Mix</strong> — The mix of employment types and occupied housing. 
+            A block group with diverse employment types (office, retail, service) plus many occupied housing units will have a higher score.
           </li>
           <li>
-            <strong>D2B (employment)</strong> — Employment density and mix.
+            <strong>D2B: Employment Mix</strong> — The mix of employment types in a block group (retail, office, industrial). 
+            Higher values indicate greater diversity of employment types.
           </li>
           <li>
-            <strong>D3B (connectivity)</strong> — Street network connectivity (intersection density, block size).
+            <strong>D3B: Street Intersection Density</strong> — The density of street intersections. 
+            Higher intersection density is correlated with more walk trips and better street connectivity.
           </li>
           <li>
-            <strong>D4A (transit)</strong> — Transit stop availability and frequency.
+            <strong>D4A: Proximity to Transit Stops</strong> — Distance from population center to nearest transit stop. 
+            Shorter distances (higher scores) correlate with more walk trips.
           </li>
         </ul>
       </section>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -34,6 +34,10 @@ export interface Metrics {
 export interface BlockGroupFeature {
   geoid20: string | null;
   natwalkind: number | null;
+  d2a_ranked: number | null; // Employment and Household Mix
+  d2b_ranked: number | null; // Employment Mix
+  d3b_ranked: number | null; // Street Intersection Density
+  d4a_ranked: number | null; // Proximity to Transit Stops
   geometry: GeoJSON.Geometry;
 }
 

--- a/services/profile_summary.py
+++ b/services/profile_summary.py
@@ -13,9 +13,10 @@ from services.walkability import get_location, query_walkability_by_coords, vali
 _log = logging.getLogger(__name__)
 
 # Bumped when block_groups was added to the response payload.
+# Bumped again when component scores (d2a, d2b, d3b, d4a) were added to block_groups.
 # The API is always forward-compatible (new fields have defaults), so this
 # string is documentary only — the frontend does not gate on it.
-SCHEMA_VERSION = "2026-02-19"
+SCHEMA_VERSION = "2026-02-19-component-scores"
 
 
 def _validate_coordinates(lat: float, lon: float) -> tuple[float, float]:
@@ -148,13 +149,23 @@ def _build_response(
     if selected_gdf is not None and "geometry" in selected_gdf.columns:
         geoid_vals = selected_gdf["geoid20"].tolist() if "geoid20" in selected_gdf.columns else [None] * len(selected_gdf)
         nwi_vals = selected_gdf["natwalkind"].tolist() if "natwalkind" in selected_gdf.columns else [None] * len(selected_gdf)
-        for geoid20, natwalkind, geom in zip(geoid_vals, nwi_vals, selected_gdf["geometry"], strict=True):
+        d2a_vals = selected_gdf["d2a_ranked"].tolist() if "d2a_ranked" in selected_gdf.columns else [None] * len(selected_gdf)
+        d2b_vals = selected_gdf["d2b_ranked"].tolist() if "d2b_ranked" in selected_gdf.columns else [None] * len(selected_gdf)
+        d3b_vals = selected_gdf["d3b_ranked"].tolist() if "d3b_ranked" in selected_gdf.columns else [None] * len(selected_gdf)
+        d4a_vals = selected_gdf["d4a_ranked"].tolist() if "d4a_ranked" in selected_gdf.columns else [None] * len(selected_gdf)
+        for geoid20, natwalkind, d2a, d2b, d3b, d4a, geom in zip(
+            geoid_vals, nwi_vals, d2a_vals, d2b_vals, d3b_vals, d4a_vals, selected_gdf["geometry"], strict=True
+        ):
             geom_json = _geom_to_geojson(geom)
             if geom_json is None:
                 continue
             block_groups.append({
                 "geoid20": str(geoid20) if pd.notna(geoid20) else None,
                 "natwalkind": _safe_float(natwalkind),
+                "d2a_ranked": _safe_float(d2a),
+                "d2b_ranked": _safe_float(d2b),
+                "d3b_ranked": _safe_float(d3b),
+                "d4a_ranked": _safe_float(d4a),
                 "geometry": geom_json,
             })
 


### PR DESCRIPTION
- Add Dashboard page with component visualizations (distributions, correlations, contributions, comparisons)
- Add component scores (d2a, d2b, d3b, d4a) to block_groups API response
- Create centralized component labels module with EPA-accurate naming
- Install Recharts for data visualization
- Update component labels throughout: D2A (Employment and Household Mix), D2B (Employment Mix), D3B (Street Intersection Density), D4A (Proximity to Transit Stops)
- Add research document on NWI analytics and dashboard patterns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new user-facing route and increases the API response surface area by returning additional per-block-group fields; primary risk is contract/data-shape mismatches between backend and frontend and the added charting dependency.
> 
> **Overview**
> Adds a new **Component Analysis Dashboard** at `/dashboard` with Recharts-based visualizations (component score distributions, component↔NWI correlations with selector + Pearson coefficients, and component mean contribution/comparison), plus associated styling and a chart error boundary.
> 
> Extends the API contract and payload so `block_groups` now includes the four ranked component scores (`d2a_ranked`, `d2b_ranked`, `d3b_ranked`, `d4a_ranked`), bumps the documented `SCHEMA_VERSION`, and updates frontend types/docs/Method copy to use EPA-accurate component naming. Also adds dashboard documentation/research notes and updates README + navigation to include the new page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 624dc77691fcfe13f8f5872712aba4fd13fae66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->