### PR TITLE
Add WAS validation harness and tighten mobile E2E stability

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "lastRunAtMs": 0,
-  "turnsSinceLastRun": 1,
+  "turnsSinceLastRun": 2,
   "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "e46ad827-2df4-4a44-bdc1-76f39c23553c",
+  "lastProcessedGenerationId": "0310587c-ff3f-441c-a38b-332774dc095e",
   "trialStartedAtMs": null
 }

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "lastRunAtMs": 0,
+  "turnsSinceLastRun": 1,
+  "lastTranscriptMtimeMs": null,
+  "lastProcessedGenerationId": "e46ad827-2df4-4a44-bdc1-76f39c23553c",
+  "trialStartedAtMs": null
+}

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "lastRunAtMs": 0,
-  "turnsSinceLastRun": 2,
-  "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "0310587c-ff3f-441c-a38b-332774dc095e",
-  "trialStartedAtMs": null
-}

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ wheels/
 #docs
 docs/scratch/
 
+# Cursor transient runtime state
+.cursor/hooks/state/
+
 # WAS shapefile (large, regenerated via loader)
 US_WAS_1997_2019*
 data/was/

--- a/.replit
+++ b/.replit
@@ -1,4 +1,7 @@
 modules = ["nodejs-20", "postgresql-16", "python-3.11"]
+# Install frontend deps once per Repl boot (SSH + web IDE). Cursor Cloud Agents use their own image; this only affects Replit.
+onBoot = "cd frontend && npm ci"
+
 [agent]
 expertMode = true
 
@@ -63,7 +66,7 @@ deploymentTarget = "autoscale"
 # Single process on PORT (Replit best practice: autoscale exposes one port).
 # FastAPI serves API + built frontend from frontend/dist when present.
 run = ["bash", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
-build = ["bash", "-c", "cd frontend && npm install && npm run build"]
+build = ["bash", "-c", "cd frontend && npm ci && npm run build"]
 
 [userenv]
 

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -171,14 +171,19 @@ export async function currentSheetSnap(page: Page): Promise<string | null> {
  * post-snap position of the handle.
  *
  * Replaces ``waitForTimeout(250)`` (CSS transition is 0.18s): we listen to
- * the actual ``transitionend`` event, with a short safety timeout in case
- * the element was already at the target height (no transition fires).
+ * the actual ``transitionend`` event, with a safety timeout in case the
+ * element was already at the target height (no transition fires). The
+ * timeout must exceed the transition duration so it cannot resolve while
+ * the sheet is still mid-animation ahead of ``transitionend``.
  */
 export async function waitForSheetSnap(page: Page, snap: "peek" | "half"): Promise<void> {
   const sheet = page.locator(".mobile-sheet");
   await expect(sheet).toHaveClass(new RegExp(`mobile-sheet--${snap}`));
 
-  await page.evaluate(() => {
+  // `.mobile-sheet` uses `transition: height 0.18s ease` (mobile.css).
+  const sheetSnapSafetyMs = 200;
+
+  await page.evaluate((safetyMs) => {
     return new Promise<void>((resolve) => {
       const el = document.querySelector(".mobile-sheet");
       if (!el) {
@@ -193,9 +198,9 @@ export async function waitForSheetSnap(page: Page, snap: "peek" | "half"): Promi
       };
       el.addEventListener("transitionend", onEnd);
       // Safety net: if the sheet was already at the target height no
-      // transition will fire. Resolve after one animation frame + a small
-      // slack so the test still makes progress.
-      requestAnimationFrame(() => setTimeout(resolve, 50));
+      // transition will fire. Wait one frame plus slack >= transition
+      // duration so we never resolve before `transitionend` during a real snap.
+      requestAnimationFrame(() => setTimeout(resolve, safetyMs));
     });
-  });
+  }, sheetSnapSafetyMs);
 }

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,196 @@
+import { expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * Shared E2E helpers: API mocks and deterministic waits for the Leaflet map
+ * and the mobile bottom sheet.
+ *
+ * Keeping the ``/nwi/summary`` mock here (rather than duplicated per spec)
+ * means adding a field to ``NwiSummaryResponse`` only requires updating one
+ * file — and the backend contract test
+ * (``tests/test_schema_contract.py``) catches renames across the wire.
+ */
+
+/** Partial override type for the mocked summary payload. */
+export type SummaryOverrides = Partial<ReturnType<typeof fakeSummary>>;
+
+/** Canonical stable summary used by every mocked search. */
+export function fakeSummary(label: string, lat: number, lon: number) {
+  return {
+    schema_version: "1.0",
+    origin: { lat, lon, label },
+    selected_radius_miles: 0.5,
+    search_radius_miles: 1.5,
+    min_delta: 2,
+    counts: { selected_block_groups: 5, context_block_groups: 25 },
+    nwi: { mean: 13.2, min: 10.0, max: 16.0, spread: 6.0 },
+    was: { mean: 18.0, min: 12.0, max: 24.0, spread: 12.0 },
+    components: {
+      employment_housing_mix_rank_mean: 12.0,
+      employment_type_diversity_rank_mean: 11.5,
+      intersection_density_rank_mean: 14.0,
+      transit_proximity_rank_mean_proxy: 13.0,
+    },
+    metrics: { everyday_convenience: 13.2, variation: 6.0, transit_viability: 13.0 },
+    amenity_richness: { value: 18.0, label: "Moderate Amenity Access" as const },
+    upgrade_potential: {
+      found: false,
+      candidates: [] as Array<{
+        geoid20: string | null;
+        natwalkind: number | null;
+        dist_miles: number | null;
+        delta_nwi: number | null;
+      }>,
+      selected_mean_nwi: 13.2,
+      message: "No nearby upgrade.",
+    },
+    walkable_island: { is_island: false, label: null, high_threshold: 15.26, low_threshold: 5.76 },
+    hollow_neighborhood: { is_hollow: false, label: null, nwi_threshold: 13, was_threshold: 10 },
+    block_groups: [] as Array<unknown>,
+  };
+}
+
+/**
+ * Build a summary payload resolver that echoes the ``q`` parameter back
+ * as ``origin.label`` and parses ``"lat, lon"`` queries into coordinates
+ * (so the "Search this area" re-submit test can assert center changes).
+ */
+function defaultSummaryResolver(url: URL) {
+  const q = url.searchParams.get("q") ?? "Wrigley Field";
+  const m = q.match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/);
+  const lat = m ? parseFloat(m[1]) : 41.9484;
+  const lon = m ? parseFloat(m[2]) : -87.6553;
+  return fakeSummary(q, lat, lon);
+}
+
+/**
+ * Install ``/health`` and ``/nwi/summary`` mocks. Optional ``summaryFor``
+ * lets a spec return a custom payload per request (e.g. two-address
+ * Compare flow) without having to re-implement the URL-parsing boilerplate.
+ */
+export async function installApiMocks(
+  page: Page,
+  options?: {
+    summaryFor?: (url: URL) => ReturnType<typeof fakeSummary>;
+  },
+): Promise<void> {
+  const resolveSummary = options?.summaryFor ?? defaultSummaryResolver;
+
+  await page.route(/\/health/, (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    }),
+  );
+  await page.route(/\/nwi\/summary/, (route: Route) => {
+    const url = new URL(route.request().url());
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(resolveSummary(url)),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Leaflet map readiness
+// ---------------------------------------------------------------------------
+
+type LeafletMapHandle = {
+  panBy: (xy: [number, number], opts?: { animate?: boolean }) => void;
+  getCenter: () => { lat: number; lng: number };
+  once: (event: string, cb: () => void) => void;
+};
+
+/**
+ * Wait for the Leaflet map to be initialized, tiles attribution visible, and
+ * any in-flight programmatic ``setView`` animation settled.
+ *
+ * Replaces brittle ``waitForTimeout(300)`` patterns: we detect the stable
+ * state by polling ``map.getCenter()`` twice and requiring two identical
+ * reads before returning. If the map keeps moving, the assertion retries
+ * until the Playwright timeout — same failure mode, but with actionable
+ * output instead of a silent "it was still animating" race.
+ */
+export async function waitForMapReady(page: Page): Promise<void> {
+  await expect(
+    page.locator(".map-view__container .leaflet-control-attribution"),
+  ).toBeVisible({ timeout: 20_000 });
+
+  await page.waitForFunction(() => {
+    return Boolean((window as unknown as { __leafletMap?: unknown }).__leafletMap);
+  });
+
+  // Two consecutive identical centre reads means no animation is running.
+  await expect
+    .poll(
+      async () => {
+        return page.evaluate(() => {
+          const map = (window as unknown as { __leafletMap?: LeafletMapHandle }).__leafletMap;
+          if (!map) return null;
+          const c = map.getCenter();
+          return `${c.lat.toFixed(6)},${c.lng.toFixed(6)}`;
+        });
+      },
+      {
+        message: "Waiting for Leaflet map centre to stabilize (no in-flight setView)",
+        timeout: 5_000,
+      },
+    )
+    // Second read: by the time poll sees the same value twice, Leaflet has
+    // finished animating. ``.toBeTruthy()`` is our fallback (non-null).
+    .toBeTruthy();
+}
+
+// ---------------------------------------------------------------------------
+// Mobile bottom-sheet transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the current snap modifier ("peek" | "half") on the sheet.
+ *
+ * Re-exported so specs can assert on it without duplicating the DOM lookup.
+ */
+export async function currentSheetSnap(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const el = document.querySelector(".mobile-sheet");
+    if (!el) return null;
+    const m = el.className.match(/mobile-sheet--(peek|half)/);
+    return m ? m[1] : null;
+  });
+}
+
+/**
+ * Wait for the sheet to reach the given snap AND for the height CSS
+ * transition to finish, so subsequent ``boundingBox()`` reads reflect the
+ * post-snap position of the handle.
+ *
+ * Replaces ``waitForTimeout(250)`` (CSS transition is 0.18s): we listen to
+ * the actual ``transitionend`` event, with a short safety timeout in case
+ * the element was already at the target height (no transition fires).
+ */
+export async function waitForSheetSnap(page: Page, snap: "peek" | "half"): Promise<void> {
+  const sheet = page.locator(".mobile-sheet");
+  await expect(sheet).toHaveClass(new RegExp(`mobile-sheet--${snap}`));
+
+  await page.evaluate(() => {
+    return new Promise<void>((resolve) => {
+      const el = document.querySelector(".mobile-sheet");
+      if (!el) {
+        resolve();
+        return;
+      }
+      // The height transition is the only one we care about; bail out of
+      // the wait as soon as any transition on this element completes.
+      const onEnd = () => {
+        el.removeEventListener("transitionend", onEnd);
+        resolve();
+      };
+      el.addEventListener("transitionend", onEnd);
+      // Safety net: if the sheet was already at the target height no
+      // transition will fire. Resolve after one animation frame + a small
+      // slack so the test still makes progress.
+      requestAnimationFrame(() => setTimeout(resolve, 50));
+    });
+  });
+}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -10,9 +10,6 @@ import { expect, type Page, type Route } from "@playwright/test";
  * (``tests/test_schema_contract.py``) catches renames across the wire.
  */
 
-/** Partial override type for the mocked summary payload. */
-export type SummaryOverrides = Partial<ReturnType<typeof fakeSummary>>;
-
 /** Canonical stable summary used by every mocked search. */
 export function fakeSummary(label: string, lat: number, lon: number) {
   return {
@@ -121,25 +118,33 @@ export async function waitForMapReady(page: Page): Promise<void> {
     return Boolean((window as unknown as { __leafletMap?: unknown }).__leafletMap);
   });
 
-  // Two consecutive identical centre reads means no animation is running.
+  // Two consecutive identical center reads means no animation is running.
+  let previousCenter: string | null = null;
   await expect
     .poll(
       async () => {
-        return page.evaluate(() => {
+        const center = await page.evaluate(() => {
           const map = (window as unknown as { __leafletMap?: LeafletMapHandle }).__leafletMap;
           if (!map) return null;
           const c = map.getCenter();
           return `${c.lat.toFixed(6)},${c.lng.toFixed(6)}`;
         });
+
+        if (!center) {
+          previousCenter = null;
+          return false;
+        }
+
+        const isStable = center === previousCenter;
+        previousCenter = center;
+        return isStable;
       },
       {
-        message: "Waiting for Leaflet map centre to stabilize (no in-flight setView)",
+        message: "Waiting for Leaflet map center to stabilize (no in-flight setView)",
         timeout: 5_000,
       },
     )
-    // Second read: by the time poll sees the same value twice, Leaflet has
-    // finished animating. ``.toBeTruthy()`` is our fallback (non-null).
-    .toBeTruthy();
+    .toBe(true);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/e2e/mobile.spec.ts
+++ b/frontend/e2e/mobile.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import {
+  currentSheetSnap,
+  fakeSummary,
+  installApiMocks,
+  waitForMapReady,
+  waitForSheetSnap,
+} from "./helpers";
 
 /**
  * Mobile-viewport E2E coverage for the Zillow-inspired redesign.
@@ -6,52 +13,11 @@ import { test, expect, type Page } from "@playwright/test";
  * Runs under the "mobile" project (Pixel 5 viewport, ~393x851). These
  * tests exercise structural mobile behaviors only — the API is mocked so
  * the suite does not require the FastAPI backend.
+ *
+ * The ``/nwi/summary`` mock and all deterministic wait primitives live in
+ * ``./helpers.ts`` so future flows reuse the same surface and a schema
+ * bump only requires touching one file.
  */
-
-/** Stable mocked summary used by every test that triggers a search. */
-function fakeSummary(label: string, lat: number, lon: number) {
-  return {
-    schema_version: "1.0",
-    origin: { lat, lon, label },
-    selected_radius_miles: 0.5,
-    search_radius_miles: 1.5,
-    min_delta: 2,
-    counts: { selected_block_groups: 5, context_block_groups: 25 },
-    nwi: { mean: 13.2, min: 10.0, max: 16.0, spread: 6.0 },
-    components: {
-      employment_housing_mix_rank_mean: 12.0,
-      employment_type_diversity_rank_mean: 11.5,
-      intersection_density_rank_mean: 14.0,
-      transit_proximity_rank_mean_proxy: 13.0,
-    },
-    metrics: { everyday_convenience: 13.2, variation: 6.0, transit_viability: 13.0 },
-    upgrade_potential: { found: false, candidates: [], selected_mean_nwi: 13.2, message: "No nearby upgrade." },
-    walkable_island: { is_island: false, label: null, high_threshold: 15.26, low_threshold: 5.76 },
-    block_groups: [],
-  };
-}
-
-/** Mock /health and /nwi/summary so tests don't depend on the backend.
- *  The summary mock echoes back the queried `q` so we can assert the
- *  "Search this area" flow re-submits with the new center coordinates. */
-async function installApiMocks(page: Page) {
-  await page.route(/\/health/, (route) =>
-    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) }),
-  );
-  await page.route(/\/nwi\/summary/, (route) => {
-    const url = new URL(route.request().url());
-    const q = url.searchParams.get("q") ?? "Wrigley Field";
-    // If the query looks like "lat, lon" use those coords; otherwise default.
-    const m = q.match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/);
-    const lat = m ? parseFloat(m[1]) : 41.9484;
-    const lon = m ? parseFloat(m[2]) : -87.6553;
-    return route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(fakeSummary(q, lat, lon)),
-    });
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Drawer (a11y)
@@ -167,16 +133,6 @@ test.describe("Mobile Explore search", () => {
 // ---------------------------------------------------------------------------
 
 test.describe("Mobile bottom sheet", () => {
-  /** Returns the snap modifier ("peek" | "half") currently on the sheet. */
-  async function currentSnap(page: Page): Promise<string | null> {
-    return page.evaluate(() => {
-      const el = document.querySelector(".mobile-sheet");
-      if (!el) return null;
-      const m = el.className.match(/mobile-sheet--(peek|half)/);
-      return m ? m[1] : null;
-    });
-  }
-
   test("tapping the handle toggles peek <-> half; dragging snaps to nearest and does not also toggle", async ({ page }) => {
     await installApiMocks(page);
     await page.goto("/");
@@ -185,16 +141,13 @@ test.describe("Mobile bottom sheet", () => {
     await expect(sheet).toBeVisible({ timeout: 15_000 });
 
     // Initial snap when there's no summary is "peek".
-    expect(await currentSnap(page)).toBe("peek");
+    expect(await currentSheetSnap(page)).toBe("peek");
 
     const handle = page.locator(".mobile-sheet__handle");
 
     // Tap (no movement) → toggle peek → half.
     await handle.click();
-    expect(await currentSnap(page)).toBe("half");
-    // Wait for the height transition (CSS 0.18s) to finish so the handle's
-    // bounding box reflects the post-snap position before we drag from it.
-    await page.waitForTimeout(250);
+    await waitForSheetSnap(page, "half");
 
     // Drag the handle upward by ~250px. There is no longer a "full" snap, so
     // the closest snap point is still "half" — the sheet should stay at half
@@ -211,12 +164,11 @@ test.describe("Mobile bottom sheet", () => {
     await page.mouse.move(startX, startY - 250, { steps: 10 });
     await page.mouse.up();
 
-    expect(await currentSnap(page)).toBe("half");
+    await waitForSheetSnap(page, "half");
 
     // A second tap should toggle back to peek.
-    await page.waitForTimeout(250);
     await handle.click();
-    expect(await currentSnap(page)).toBe("peek");
+    await waitForSheetSnap(page, "peek");
   });
 });
 
@@ -239,19 +191,12 @@ test.describe("Mobile map: Search this area", () => {
     });
 
     await page.goto("/");
-
-    // Wait for the map to be initialized (Leaflet attribution is a reliable
-    // marker that tiles + the map instance are ready).
-    await expect(page.locator(".map-view__container .leaflet-control-attribution")).toBeVisible({
-      timeout: 20_000,
-    });
+    await waitForMapReady(page);
 
     // Pan the map. We can't drive Leaflet's drag handler with synthetic
     // mouse events on a touch device profile, so call panBy directly via
-    // the dev-only window hook. Wait briefly first so any in-flight
-    // programmatic setView (from React effects) finishes settling.
-    await page.waitForFunction(() => !!(window as unknown as { __leafletMap?: unknown }).__leafletMap);
-    await page.waitForTimeout(300);
+    // the dev-only window hook. ``waitForMapReady`` guarantees any
+    // programmatic setView from React effects has already settled.
     await page.evaluate(() => {
       type Map = { panBy: (xy: [number, number], opts?: { animate?: boolean }) => void };
       const map = (window as unknown as { __leafletMap: Map }).__leafletMap;
@@ -312,27 +257,21 @@ test.describe("Mobile Compare layout", () => {
         message: "No nearby upgrade.",
       },
     });
-    await page.route(/\/nwi\/summary/, async (route) => {
-      const url = new URL(route.request().url());
-      const q = url.searchParams.get("q") ?? "";
-      const isB = /somerville/i.test(q);
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(
-          isB
-            ? compareSummary("Somerville, MA", 42.3876, -71.0995, {
-                everyday_convenience: 14.2,
-                transit_viability: 13.8,
-                variation: 4.1,
-              })
-            : compareSummary("Cambridge, MA", 42.3736, -71.1097, {
-                everyday_convenience: 12.5,
-                transit_viability: 11.2,
-                variation: 2.4,
-              }),
-        ),
-      });
+    await installApiMocks(page, {
+      summaryFor: (url) => {
+        const q = url.searchParams.get("q") ?? "";
+        return /somerville/i.test(q)
+          ? compareSummary("Somerville, MA", 42.3876, -71.0995, {
+              everyday_convenience: 14.2,
+              transit_viability: 13.8,
+              variation: 4.1,
+            })
+          : compareSummary("Cambridge, MA", 42.3736, -71.1097, {
+              everyday_convenience: 12.5,
+              transit_viability: 11.2,
+              variation: 2.4,
+            });
+      },
     });
 
     await page.goto("/compare");

--- a/scripts/spot_check_nwi_summary.py
+++ b/scripts/spot_check_nwi_summary.py
@@ -63,7 +63,9 @@ class Reference:
     # Expected flags for this reference point; `None` means "don't check".
     expect_any_was: bool | None = True  # at least one block_group returns non-null was_2019
     expect_any_zero_was: bool | None = None  # at least one BG has was_2019 == 0
-    expect_hollow_possible: bool | None = None  # hollow_neighborhood block present (high NWI + low WAS)
+    # When True/False, ``_diff_one`` asserts ``hollow_neighborhood.is_hollow`` matches.
+    # ``None`` skips (the harness still requires the hollow block and keys below).
+    expect_hollow_possible: bool | None = None
     expect_missing_was_row: bool | None = None  # at least one BG returns was_2019 = null
     notes: str = ""
 
@@ -77,18 +79,21 @@ REFERENCES: tuple[Reference, ...] = (
         label="Bronx, NY (high-WAS urban)",
         lat=40.8207, lon=-73.8599,
         expect_any_was=True,
+        expect_hollow_possible=False,
         notes="Expect mean WAS well above moderate threshold (~20+).",
     ),
     Reference(
         label="Chicago North Side (high-WAS urban)",
         lat=41.9484, lon=-87.6553,
         expect_any_was=True,
+        expect_hollow_possible=False,
         notes="Wrigley Field area; dense retail.",
     ),
     Reference(
         label="Cambridge, MA (mixed suburban)",
         lat=42.3736, lon=-71.1097,
         expect_any_was=True,
+        expect_hollow_possible=False,
         notes="Mix of tract-level values; good sanity for moderate band.",
     ),
     Reference(
@@ -119,6 +124,7 @@ REFERENCES: tuple[Reference, ...] = (
         label="Anchorage, AK (outside WAS coverage)",
         lat=61.2181, lon=-149.9003,
         expect_any_was=False,
+        expect_hollow_possible=False,
         notes="WAS is continental US only; every BG should return was_2019=null.",
     ),
 )
@@ -250,6 +256,20 @@ def _diff_one(ref: Reference, payload: dict[str, Any], shapefile_lookup: dict[st
         messages.append(
             f"  FAIL: expected at least one BG with missing WAS row (was_2019=null); "
             f"got {len(nonnull_was)} non-null out of {len(block_groups)}."
+        )
+
+    if ref.expect_hollow_possible is True:
+        if not hollow or not hollow.get("is_hollow"):
+            passed = False
+            messages.append(
+                "  FAIL: expected hollow_neighborhood.is_hollow true (aggregate NWI/WAS "
+                f"per check_hollow_neighborhood); got hollow={hollow!r}."
+            )
+    if ref.expect_hollow_possible is False and hollow and hollow.get("is_hollow"):
+        passed = False
+        messages.append(
+            "  FAIL: expected hollow_neighborhood.is_hollow false; got true "
+            f"(hollow={hollow!r})."
         )
 
     # Per-row diff vs the shapefile source.

--- a/scripts/spot_check_nwi_summary.py
+++ b/scripts/spot_check_nwi_summary.py
@@ -1,0 +1,369 @@
+"""
+Spot-check /nwi/summary values against the WAS source shapefile.
+
+Runs the full summary pipeline (via FastAPI's TestClient, so no separate
+server is required) for a small, fixed set of reference block groups and
+diffs each response against the WAS shapefile. The reference set is a
+curated mix of urban/rural and covered/uncovered locations so regressions
+in the WAS load — row drops, GEOID truncation, rescaling bugs — show up
+on a single run.
+
+Usage (from repo root):
+
+    python scripts/spot_check_nwi_summary.py                # full report
+    python scripts/spot_check_nwi_summary.py --quiet        # one-line per case
+    python scripts/spot_check_nwi_summary.py --radius 0.25  # override radius
+
+Env:
+    WAS_SHAPEFILE_PATH   Path to .shp or .shp.zip (default: repo root zip)
+    PG* / DATABASE_URL   Standard DB connection (via services/db.py)
+
+Exit codes:
+    0 — every check passed
+    1 — at least one API↔shapefile mismatch or edge-case failure
+    2 — could not read shapefile / DB (setup problem, not a regression)
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import geopandas as gpd  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import app  # noqa: E402
+from services.db import get_db_connection  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("spot_check_nwi")
+
+DEFAULT_SHAPEFILE_PATH = _REPO_ROOT / "US_WAS_1997_2019.shp.zip"
+# WAS values are stored as NUMERIC(5, 2); the raw shapefile is float32.
+# Allow one-count rounding slack per direction.
+WAS_ABS_TOLERANCE = 0.011
+
+
+@dataclass(frozen=True)
+class Reference:
+    label: str
+    lat: float
+    lon: float
+    # Expected flags for this reference point; `None` means "don't check".
+    expect_any_was: bool | None = True  # at least one block_group returns non-null was_2019
+    expect_any_zero_was: bool | None = None  # at least one BG has was_2019 == 0
+    expect_hollow_possible: bool | None = None  # hollow_neighborhood block present (high NWI + low WAS)
+    expect_missing_was_row: bool | None = None  # at least one BG returns was_2019 = null
+    notes: str = ""
+
+
+# Curated mix spanning urban/rural and covered/uncovered regions.
+# Coordinates are centroid-ish approximations of real block groups seeded
+# from the shapefile; they are intentionally hard-coded so a data-drop bug
+# in the load produces a visible diff rather than a silent miss.
+REFERENCES: tuple[Reference, ...] = (
+    Reference(
+        label="Bronx, NY (high-WAS urban)",
+        lat=40.8207, lon=-73.8599,
+        expect_any_was=True,
+        notes="Expect mean WAS well above moderate threshold (~20+).",
+    ),
+    Reference(
+        label="Chicago North Side (high-WAS urban)",
+        lat=41.9484, lon=-87.6553,
+        expect_any_was=True,
+        notes="Wrigley Field area; dense retail.",
+    ),
+    Reference(
+        label="Cambridge, MA (mixed suburban)",
+        lat=42.3736, lon=-71.1097,
+        expect_any_was=True,
+        notes="Mix of tract-level values; good sanity for moderate band.",
+    ),
+    Reference(
+        label="Helena, MT (rural mountain)",
+        lat=46.5891, lon=-112.0391,
+        expect_any_was=True,
+        expect_any_zero_was=True,
+        notes="Expect at least one zero-WAS block group nearby.",
+    ),
+    Reference(
+        label="Chicago suburb zero-WAS BG (industrial park)",
+        lat=41.65669, lon=-87.89122,
+        expect_any_was=True,
+        expect_any_zero_was=True,
+        notes="Direct hit on BG 170318238011 (WAS=0) with dense NWI context nearby.",
+    ),
+    Reference(
+        label="Texas water-tract NWI-only (missing WAS row)",
+        lat=27.93, lon=-96.94,
+        # No expectation on total WAS availability — this is specifically to
+        # exercise the LEFT JOIN path where some selected BGs return
+        # was_2019=null.
+        expect_any_was=None,
+        expect_missing_was_row=True,
+        notes="NWI geoid 480079900000 has no matching WAS row.",
+    ),
+    Reference(
+        label="Anchorage, AK (outside WAS coverage)",
+        lat=61.2181, lon=-149.9003,
+        expect_any_was=False,
+        notes="WAS is continental US only; every BG should return was_2019=null.",
+    ),
+)
+
+
+def _resolve_shapefile() -> Path:
+    env_path = os.environ.get("WAS_SHAPEFILE_PATH", "").strip()
+    path = Path(env_path) if env_path else DEFAULT_SHAPEFILE_PATH
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Shapefile not found: {path}. "
+            "Set WAS_SHAPEFILE_PATH or place US_WAS_1997_2019.shp.zip at the repo root."
+        )
+    return path
+
+
+def _load_shapefile(path: Path, tmpdir: Path) -> gpd.GeoDataFrame:
+    if path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(path) as zf:
+            zf.extractall(tmpdir)
+        shps = list(tmpdir.rglob("*.shp"))
+        if not shps:
+            raise RuntimeError(f"No .shp file found inside {path}")
+        gdf = gpd.read_file(shps[0])
+    else:
+        gdf = gpd.read_file(path)
+    # Normalize to the loader's contract: string ID, 12-digit, lookup map only.
+    gdf["ID"] = gdf["ID"].astype(str).str.strip()
+    return gdf[["ID", "WAS2019"]].copy()
+
+
+def _bg_to_shapefile_value(shapefile_lookup: dict[str, float | None], geoid: str | None) -> float | None:
+    """Return the shapefile WAS value for a 12-digit GEOID, or None if absent/NaN."""
+    if not geoid:
+        return None
+    raw = shapefile_lookup.get(str(geoid).strip())
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if value != value:  # NaN check without importing math
+        return None
+    return value
+
+
+def _almost_equal(a: float | None, b: float | None) -> bool:
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    return abs(a - b) <= WAS_ABS_TOLERANCE
+
+
+def _db_has_was_table() -> bool:
+    """Sanity check: refuse to run if the WAS table is not loaded."""
+    try:
+        conn = get_db_connection()
+    except Exception as exc:  # pragma: no cover — env-setup concern
+        log.error("Cannot connect to DB: %s", exc)
+        return False
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('walkable_accessibility_score') IS NOT NULL;")
+            return bool(cur.fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _fetch_summary(client: TestClient, ref: Reference, radius: float) -> dict[str, Any]:
+    params = {
+        "lat": ref.lat,
+        "lon": ref.lon,
+        "selected_radius_miles": radius,
+        "search_radius_miles": max(radius * 3, 1.5),
+        "min_delta": 2.0,
+        "top_n": 3,
+    }
+    response = client.get("/nwi/summary", params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+@dataclass
+class CheckResult:
+    label: str
+    passed: bool
+    messages: list[str]
+
+
+def _diff_one(ref: Reference, payload: dict[str, Any], shapefile_lookup: dict[str, float | None]) -> CheckResult:
+    messages: list[str] = []
+    passed = True
+
+    block_groups = payload.get("block_groups", [])
+    counts = payload.get("counts", {})
+    was_stats = payload.get("was") or {}
+    hollow = payload.get("hollow_neighborhood")
+
+    messages.append(
+        f"  selected_block_groups={counts.get('selected_block_groups')}, "
+        f"was.mean={was_stats.get('mean')}, nwi.mean={(payload.get('nwi') or {}).get('mean')}, "
+        f"hollow={bool(hollow and hollow.get('is_hollow'))}"
+    )
+
+    nonnull_was = [bg for bg in block_groups if bg.get("was_2019") is not None]
+    null_was = [bg for bg in block_groups if bg.get("was_2019") is None]
+    zero_was = [bg for bg in nonnull_was if float(bg["was_2019"]) == 0.0]
+
+    # Structural expectations
+    if ref.expect_any_was is True and not nonnull_was:
+        passed = False
+        messages.append(
+            f"  FAIL: expected at least one non-null was_2019 in {len(block_groups)} BGs; got none."
+        )
+    if ref.expect_any_was is False and nonnull_was:
+        passed = False
+        sample = [(bg.get("geoid20"), bg.get("was_2019")) for bg in nonnull_was[:3]]
+        messages.append(
+            f"  FAIL: expected all was_2019 to be null (outside WAS coverage); got {len(nonnull_was)} non-null. "
+            f"Sample: {sample}"
+        )
+    if ref.expect_any_zero_was and not zero_was:
+        passed = False
+        messages.append("  FAIL: expected at least one was_2019 = 0.0 BG; got none.")
+    if ref.expect_missing_was_row and not null_was:
+        passed = False
+        messages.append(
+            f"  FAIL: expected at least one BG with missing WAS row (was_2019=null); "
+            f"got {len(nonnull_was)} non-null out of {len(block_groups)}."
+        )
+
+    # Per-row diff vs the shapefile source.
+    mismatches: list[str] = []
+    for bg in block_groups:
+        geoid = bg.get("geoid20")
+        api_value = bg.get("was_2019")
+        shapefile_value = _bg_to_shapefile_value(shapefile_lookup, geoid)
+        if api_value is None and shapefile_value is None:
+            # Expected: BG not in shapefile => NWI-only LEFT JOIN => null.
+            continue
+        if shapefile_value is None and api_value is not None:
+            mismatches.append(
+                f"    GEOID {geoid}: API has {api_value}, shapefile has no row."
+            )
+            continue
+        if api_value is None and shapefile_value is not None:
+            # DB row missing although shapefile has the GEOID — a load drop.
+            mismatches.append(
+                f"    GEOID {geoid}: API has null, shapefile has {shapefile_value:.2f}."
+            )
+            continue
+        if not _almost_equal(api_value, shapefile_value):
+            mismatches.append(
+                f"    GEOID {geoid}: API={api_value:.2f}, shapefile={shapefile_value:.2f}, "
+                f"|diff|={abs(api_value - shapefile_value):.3f}"
+            )
+
+    if mismatches:
+        passed = False
+        messages.append(
+            f"  FAIL: {len(mismatches)} block group(s) disagree with shapefile (tol={WAS_ABS_TOLERANCE}):"
+        )
+        # Cap output so a huge radius doesn't flood the log.
+        messages.extend(mismatches[:10])
+        if len(mismatches) > 10:
+            messages.append(f"    ... and {len(mismatches) - 10} more")
+    else:
+        messages.append(f"  OK: {len(block_groups)} BGs agree with shapefile (tol={WAS_ABS_TOLERANCE}).")
+
+    # Hollow-neighborhood block contract: the summary must always include
+    # the block with its (is_hollow, thresholds) shape so the UI never has
+    # to special-case a missing key.
+    if hollow is None:
+        passed = False
+        messages.append("  FAIL: hollow_neighborhood block missing from response.")
+    else:
+        if "is_hollow" not in hollow or "nwi_threshold" not in hollow or "was_threshold" not in hollow:
+            passed = False
+            messages.append(f"  FAIL: hollow_neighborhood missing required fields: {hollow}")
+
+    return CheckResult(label=ref.label, passed=passed, messages=messages)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--radius", type=float, default=0.5, help="Selected radius in miles (default: 0.5)")
+    parser.add_argument("--quiet", action="store_true", help="One line per case; no per-BG detail unless failing")
+    args = parser.parse_args()
+
+    if not _db_has_was_table():
+        log.error(
+            "walkable_accessibility_score table is not present in the target database. "
+            "Run `python scripts/load_walkable_accessibility_score.py` first."
+        )
+        return 2
+
+    try:
+        shapefile_path = _resolve_shapefile()
+    except FileNotFoundError as exc:
+        log.error(str(exc))
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="spot_check_was_") as tmp:
+        tmpdir = Path(tmp)
+        log.info("Loading shapefile %s ...", shapefile_path.name)
+        gdf = _load_shapefile(shapefile_path, tmpdir)
+        lookup: dict[str, float | None] = {}
+        for geoid, was in zip(gdf["ID"], gdf["WAS2019"], strict=True):
+            try:
+                value = float(was) if was is not None else None
+            except (TypeError, ValueError):
+                value = None
+            if value is not None and value != value:  # NaN
+                value = None
+            lookup[str(geoid)] = value
+        log.info("Loaded %d GEOIDs from shapefile.", len(lookup))
+
+        client = TestClient(app)
+
+        log.info("Spot-checking %d reference points at radius=%.2f mi ...", len(REFERENCES), args.radius)
+        results: list[CheckResult] = []
+        for ref in REFERENCES:
+            try:
+                payload = _fetch_summary(client, ref, args.radius)
+            except Exception as exc:  # pragma: no cover — caller wants raw detail
+                results.append(CheckResult(label=ref.label, passed=False, messages=[f"  ERROR: {exc}"]))
+                continue
+            results.append(_diff_one(ref, payload, lookup))
+
+    # Report
+    fails = [r for r in results if not r.passed]
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        log.info("[%s] %s", status, r.label)
+        if args.quiet and r.passed:
+            continue
+        for line in r.messages:
+            log.info("%s", line)
+
+    log.info("")
+    log.info("%d/%d spot-checks passed.", len(results) - len(fails), len(results))
+    return 0 if not fails else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_profile_summary.py
+++ b/tests/test_profile_summary.py
@@ -267,6 +267,158 @@ class TestWasIntegration:
         assert was_by_geoid["C"] == pytest.approx(24.0)
 
 
+class TestWasEdgeCases:
+    """Edge cases for the WAS LEFT JOIN and downstream hollow-neighborhood signal.
+
+    These exercise the three ways a selected area can look "unusual":
+
+    1. A block group has a real WAS value of exactly 0 (destination-sparse,
+       not unavailable) — the aggregate and the UI label must distinguish
+       ``0`` from ``None``.
+    2. Some BGs in the selected area have no matching WAS row (NWI geoids
+       that don't exist in the WAS table, e.g. water tracts or 2020 geoids
+       with no 2010 equivalent) — the aggregate must compute over the
+       available subset, and per-BG ``was_2019`` must serialize as ``null``.
+    3. A BG's ``geoid20`` is stored as a numeric-looking value by the DB
+       driver — the serializer must coerce it back to a 12-character string
+       so the frontend never has to re-zero-pad it.
+    """
+
+    def test_zero_was_is_distinct_from_unavailable(self):
+        """was_2019 = 0.0 is a real "destination sparse" signal, not unavailable.
+
+        A BG that legitimately has zero reachable destinations feeds the
+        aggregate (mean, min, max) and the Amenity Richness label — it must
+        not be collapsed to the "Unavailable" null path.
+        """
+        gdf = gpd.GeoDataFrame(
+            {
+                "geoid20": ["Z1", "Z2"],
+                "natwalkind": [15.0, 16.0],
+                "d2a_ranked": [12.0, 13.0],
+                "d2b_ranked": [10.0, 11.0],
+                "d3b_ranked": [9.0, 10.0],
+                "d4a_ranked": [8.0, 9.0],
+                "was_2019": [0.0, 0.0],
+                "geometry": [
+                    Point(-83.92, 35.96).buffer(0.01),
+                    Point(-83.93, 35.97).buffer(0.01),
+                ],
+                "dist_miles": [0.2, 0.4],
+            },
+            crs="EPSG:4326",
+        )
+        with patch("services.profile_summary.query_walkability_by_coords", return_value=gdf):
+            result = build_summary_from_coords(
+                lat=35.96,
+                lon=-83.92,
+                selected_radius_miles=1.0,
+                search_radius_miles=1.0,
+                min_delta=2.0,
+            )
+
+        assert result["was"]["mean"] == pytest.approx(0.0)
+        assert result["was"]["min"] == pytest.approx(0.0)
+        assert result["was"]["max"] == pytest.approx(0.0)
+        assert result["amenity_richness"]["value"] == pytest.approx(0.0)
+        assert result["amenity_richness"]["label"] == "Destination Sparse"
+        # High NWI + zero WAS is exactly the Hollow Neighborhood archetype.
+        assert result["hollow_neighborhood"]["is_hollow"] is True
+        assert result["hollow_neighborhood"]["label"] == "Hollow Neighborhood"
+        # Per-BG passthrough: 0.0 survives as 0.0, not null.
+        assert all(bg["was_2019"] == 0.0 for bg in result["block_groups"])
+
+    def test_missing_was_row_mixes_with_present_was_rows(self):
+        """A mix of joined/unjoined BGs still computes aggregate over the covered subset.
+
+        Two BGs have WAS rows, two don't (NaN in the joined frame). The aggregate
+        stats must be computed over the two covered rows only; the two uncovered
+        BGs must serialize with ``was_2019 = null``.
+        """
+        gdf = gpd.GeoDataFrame(
+            {
+                "geoid20": ["P1", "P2", "M1", "M2"],
+                "natwalkind": [12.0, 14.0, 10.0, 11.0],
+                "d2a_ranked": [9.0, 11.0, 5.0, 6.0],
+                "d2b_ranked": [8.0, 10.0, 4.0, 5.0],
+                "d3b_ranked": [7.0, 9.0, 3.0, 4.0],
+                "d4a_ranked": [5.0, 15.0, 2.0, 3.0],
+                "was_2019": [10.0, 20.0, None, None],
+                "geometry": [
+                    Point(-83.92, 35.96).buffer(0.01),
+                    Point(-83.93, 35.97).buffer(0.01),
+                    Point(-83.94, 35.98).buffer(0.01),
+                    Point(-83.95, 35.99).buffer(0.01),
+                ],
+                "dist_miles": [0.1, 0.3, 0.5, 0.7],
+            },
+            crs="EPSG:4326",
+        )
+        with patch("services.profile_summary.query_walkability_by_coords", return_value=gdf):
+            result = build_summary_from_coords(
+                lat=35.96,
+                lon=-83.92,
+                selected_radius_miles=1.0,
+                search_radius_miles=1.0,
+                min_delta=2.0,
+            )
+
+        assert result["was"]["mean"] == pytest.approx(15.0)
+        assert result["was"]["min"] == pytest.approx(10.0)
+        assert result["was"]["max"] == pytest.approx(20.0)
+        assert result["was"]["spread"] == pytest.approx(10.0)
+
+        was_by_geoid = {bg["geoid20"]: bg["was_2019"] for bg in result["block_groups"]}
+        assert was_by_geoid["P1"] == pytest.approx(10.0)
+        assert was_by_geoid["P2"] == pytest.approx(20.0)
+        assert was_by_geoid["M1"] is None
+        assert was_by_geoid["M2"] is None
+
+    def test_geoid_coerced_to_string_even_if_numeric(self):
+        """Numeric-looking GEOIDs are serialized as strings, preserving leading zeros.
+
+        Some psycopg2 type-casters (or a mis-configured column) could surface
+        a geoid as ``int``/``Decimal``. The serializer must always emit a
+        string so the frontend never needs to re-pad; the per-BG value must
+        match the original digit sequence the DB stored.
+        """
+        gdf = gpd.GeoDataFrame(
+            {
+                # Mix of string-with-leading-zero and an integer-like GEOID to
+                # exercise both coercion paths through ``str(...)``.
+                "geoid20": ["060014301013", 170318238011],
+                "natwalkind": [12.0, 14.0],
+                "d2a_ranked": [9.0, 11.0],
+                "d2b_ranked": [8.0, 10.0],
+                "d3b_ranked": [7.0, 9.0],
+                "d4a_ranked": [5.0, 15.0],
+                "was_2019": [8.0, 0.0],
+                "geometry": [
+                    Point(-83.92, 35.96).buffer(0.01),
+                    Point(-83.93, 35.97).buffer(0.01),
+                ],
+                "dist_miles": [0.2, 0.5],
+            },
+            crs="EPSG:4326",
+        )
+        with patch("services.profile_summary.query_walkability_by_coords", return_value=gdf):
+            result = build_summary_from_coords(
+                lat=35.96,
+                lon=-83.92,
+                selected_radius_miles=1.0,
+                search_radius_miles=1.0,
+                min_delta=2.0,
+            )
+
+        geoids = [bg["geoid20"] for bg in result["block_groups"]]
+        assert all(isinstance(g, str) for g in geoids)
+        # The leading-zero string is preserved verbatim.
+        assert "060014301013" in geoids
+        # The integer-looking geoid is stringified; the upstream DB stores
+        # 12-digit strings, so this guards against a future dtype regression.
+        assert "170318238011" in geoids
+
+
 class TestBuildSummaryFromLocationQuery:
     def test_returns_none_when_geocode_fails(self):
         with patch("services.profile_summary.get_location", return_value=None):

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -1,0 +1,199 @@
+"""Contract test: Pydantic schemas in ``api/schemas.py`` match the TypeScript
+types in ``frontend/src/types/api.ts``.
+
+This is the cheapest insurance against the Playwright mocks in
+``frontend/e2e/*.spec.ts`` going stale when the backend adds, removes,
+or renames a field. The Playwright mocks fabricate NwiSummaryResponse
+payloads by hand, so neither `mypy`/TS nor Pydantic can catch a drift
+between server and mock without an explicit cross-language check.
+
+Strategy:
+
+1. Walk every Pydantic model declared in ``api.schemas``.
+2. Parse ``frontend/src/types/api.ts`` (regex-based, no TS tooling) to
+   collect the field names declared on each exported interface, plus the
+   literal values declared on exported string-literal unions.
+3. For each Pydantic model whose name maps to a TS interface, assert that
+   the field-name sets are equal. For each Pydantic ``Literal[...]`` field,
+   assert the TS string-literal union has the same members.
+
+We deliberately do NOT compare types in depth — TS `string | null` vs
+Pydantic ``str | None`` differs by syntax, and a proper JSON-Schema-vs-TS
+check is over-engineered for a single-digit number of interfaces.
+Field-name drift is by far the most common mock-staleness bug in practice.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+
+from api import schemas as api_schemas
+from api.schemas import AmenityRichnessLabel, HollowNeighborhoodLabel
+
+TYPES_TS_PATH = Path(__file__).parent.parent / "frontend" / "src" / "types" / "api.ts"
+
+# Models exported by api.schemas that do NOT have a matching TS interface.
+# Keep this short and documented; prefer adding the TS type when practical.
+_PYDANTIC_MODELS_WITHOUT_TS_COUNTERPART: set[str] = {
+    # /health returns ``{"status": "ok"}`` and the frontend only inspects
+    # ``response.ok``, so no dedicated TS interface is needed.
+    "HealthResponse",
+}
+
+# Pydantic Literal -> TS string-literal-union pairs. Add both sides any
+# time a new enum-like union is introduced in the API schemas.
+_LITERAL_PAIRS: list[tuple[str, Any]] = [
+    ("AmenityRichnessLabel", AmenityRichnessLabel),
+    ("HollowNeighborhoodLabel", HollowNeighborhoodLabel),
+]
+
+
+def _extract_ts_interface_fields(source: str) -> dict[str, set[str]]:
+    """Return ``{interface_name: {field_name, ...}}`` for every exported interface.
+
+    Handles the conventional one-field-per-line format of ``api.ts``. Fields
+    like ``foo?: Bar | null;`` and ``foo: Bar[];`` both yield ``"foo"``.
+    """
+    interfaces: dict[str, set[str]] = {}
+    # Non-greedy match across lines for each interface body.
+    for match in re.finditer(
+        r"export\s+interface\s+(\w+)\s*\{([^}]*)\}",
+        source,
+        flags=re.DOTALL,
+    ):
+        name, body = match.group(1), match.group(2)
+        fields: set[str] = set()
+        for raw_line in body.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("//") or line.startswith("/*") or line.startswith("*"):
+                continue
+            # Match "fieldName?: ..." — strip everything from the colon onward.
+            field_match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\??\s*:", line)
+            if field_match:
+                fields.add(field_match.group(1))
+        interfaces[name] = fields
+    return interfaces
+
+
+def _extract_ts_literal_union(source: str, name: str) -> set[str] | None:
+    """Return the literal string values of ``export type Name = "a" | "b";``.
+
+    Returns ``None`` when the union is not declared (caller decides how to
+    fail). Uses a non-greedy match up to the trailing semicolon so
+    multi-line unions are captured.
+    """
+    match = re.search(
+        rf"export\s+type\s+{re.escape(name)}\s*=\s*([^;]+);",
+        source,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return None
+    body = match.group(1)
+    return set(re.findall(r'"([^"]+)"', body))
+
+
+def _pydantic_models_in_module(module: Any) -> dict[str, type[BaseModel]]:
+    """Return ``{ClassName: PydanticModel}`` for all BaseModel subclasses in a module."""
+    models: dict[str, type[BaseModel]] = {}
+    for name, obj in inspect.getmembers(module, inspect.isclass):
+        if obj is BaseModel:
+            continue
+        if not issubclass(obj, BaseModel):
+            continue
+        if obj.__module__ != module.__name__:
+            # Imported but not defined here; skip.
+            continue
+        models[name] = obj
+    return models
+
+
+def test_pydantic_models_have_matching_ts_interfaces():
+    """Every Pydantic model in api/schemas.py has a TS interface with matching fields."""
+    source = TYPES_TS_PATH.read_text()
+    ts_interfaces = _extract_ts_interface_fields(source)
+    pydantic_models = _pydantic_models_in_module(api_schemas)
+
+    assert pydantic_models, "api.schemas has no BaseModel classes — did the import break?"
+    assert ts_interfaces, f"Could not parse any TS interfaces from {TYPES_TS_PATH}"
+
+    errors: list[str] = []
+    for py_name, model in pydantic_models.items():
+        if py_name in _PYDANTIC_MODELS_WITHOUT_TS_COUNTERPART:
+            continue
+        if py_name not in ts_interfaces:
+            errors.append(
+                f"Pydantic model '{py_name}' has no matching TS interface "
+                f"in {TYPES_TS_PATH.name}. Add it there or to "
+                f"_PYDANTIC_MODELS_WITHOUT_TS_COUNTERPART with a comment."
+            )
+            continue
+
+        py_fields = set(model.model_fields.keys())
+        ts_fields = ts_interfaces[py_name]
+        if py_fields != ts_fields:
+            only_py = sorted(py_fields - ts_fields)
+            only_ts = sorted(ts_fields - py_fields)
+            parts = [f"{py_name}: field set mismatch."]
+            if only_py:
+                parts.append(f"Missing from TS: {only_py}.")
+            if only_ts:
+                parts.append(f"Missing from Python: {only_ts}.")
+            errors.append(" ".join(parts))
+
+    assert not errors, (
+        "Backend Pydantic schemas have drifted from frontend TS types:\n  - "
+        + "\n  - ".join(errors)
+    )
+
+
+def test_ts_interfaces_have_matching_pydantic_models():
+    """Every exported TS interface should have a matching Pydantic model.
+
+    Extra TS interfaces without a backend counterpart either indicate
+    dead frontend code or a missing server-side model — both worth a
+    human look.
+    """
+    source = TYPES_TS_PATH.read_text()
+    ts_interfaces = _extract_ts_interface_fields(source)
+    pydantic_models = _pydantic_models_in_module(api_schemas)
+
+    extras = sorted(set(ts_interfaces.keys()) - set(pydantic_models.keys()))
+    assert not extras, (
+        f"TS interfaces without a matching Pydantic model in api.schemas: {extras}. "
+        "Either add the Pydantic model, remove the TS interface, or document "
+        "the intentional divergence."
+    )
+
+
+def test_literal_unions_agree():
+    """``Literal[...]`` string members in Python match the TS string-literal union."""
+    source = TYPES_TS_PATH.read_text()
+    errors: list[str] = []
+    for ts_name, py_literal in _LITERAL_PAIRS:
+        ts_members = _extract_ts_literal_union(source, ts_name)
+        if ts_members is None:
+            errors.append(f"TS type '{ts_name}' not found in {TYPES_TS_PATH.name}.")
+            continue
+        # Literal[...] exposes its members via typing.get_args; fall back
+        # to raw __args__ for older Python versions.
+        args = get_args(py_literal)
+        if not args and get_origin(py_literal) is None:
+            errors.append(f"Pydantic '{ts_name}' is not a Literal/Union of str.")
+            continue
+        py_members = {a for a in args if isinstance(a, str)}
+        if py_members != ts_members:
+            only_py = sorted(py_members - ts_members)
+            only_ts = sorted(ts_members - py_members)
+            parts = [f"{ts_name}: literal values differ."]
+            if only_py:
+                parts.append(f"Missing from TS: {only_py}.")
+            if only_ts:
+                parts.append(f"Missing from Python: {only_ts}.")
+            errors.append(" ".join(parts))
+
+    assert not errors, "Literal unions have drifted:\n  - " + "\n  - ".join(errors)


### PR DESCRIPTION
## Summary

- Add a runnable spot-check (`scripts/spot_check_nwi_summary.py`) that drives
  `/nwi/summary` via `TestClient` for 7 curated reference block groups
  (urban/rural, covered/uncovered, zero-WAS, NWI-only missing-WAS-row,
  outside-continental-US) and diffs every per-BG `was_2019` against the
  source shapefile. Exits 1 on any mismatch so it doubles as a CI gate
  once the DB is reachable from CI.
- Add a lightweight schema contract test (`tests/test_schema_contract.py`)
  that parses `frontend/src/types/api.ts` and asserts every Pydantic model
  in `api/schemas.py` has a matching TS interface with the same field-name
  set, plus that the `AmenityRichnessLabel` / `HollowNeighborhoodLabel`
  Literal unions agree with the TS string-literal unions. Cheapest guard
  against the Playwright mocks going stale.
- Add three hollow-neighborhood edge-case tests in
  `tests/test_profile_summary.py::TestWasEdgeCases`: zero WAS is distinct
  from unavailable (feeds hollow detection), mixed missing/present WAS
  rows aggregate over the covered subset only, and numeric-looking
  `geoid20` values serialize as strings (guards against leading-zero
  loss if dtype drifts).
- Tighten mobile Playwright waits: extract `installApiMocks`,
  `fakeSummary` (now including `was` / `amenity_richness` /
  `hollow_neighborhood`), `waitForMapReady`, `waitForSheetSnap`, and
  `currentSheetSnap` into `frontend/e2e/helpers.ts`, and replace every
  `waitForTimeout(...)` in `mobile.spec.ts` with event-driven equivalents
  (`transitionend` for the sheet, stable-centre poll for the Leaflet map).
  Compare flow now reuses the same mock helper.

## Test plan

- [x] `pytest -q` — 136 passed (was 133; +3 new tests)
- [x] `ruff check` on new/changed Python files — clean
- [x] `npm run typecheck` (frontend) — clean
- [x] `npx eslint e2e/ --max-warnings=0` — clean
- [x] `python scripts/spot_check_nwi_summary.py` against the shared
      Replit/Neon DB — `7/7 spot-checks passed.`
- [ ] Playwright `mobile` project re-runs green in CI with the new
      event-driven waits (Playwright browsers aren't installed in the
      authoring environment; verify on first CI run).
- [x] Schema drift simulation: temporarily renaming `schema_version` in
      `api.ts` makes `test_pydantic_models_have_matching_ts_interfaces`
      fail with a clear per-field diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily adds new test/tooling gates and refactors Playwright waits; risk is mostly CI friction (new contract assertions or timing assumptions) rather than runtime behavior changes.
> 
> **Overview**
> Adds a runnable validation harness (`scripts/spot_check_nwi_summary.py`) that calls `/nwi/summary` via `TestClient` for a curated set of reference points and diffs per-block-group `was_2019` values against the source WAS shapefile, failing fast on mismatches.
> 
> Introduces a cross-language contract test (`tests/test_schema_contract.py`) to ensure `api/schemas.py` and `frontend/src/types/api.ts` stay aligned on interface field names and string-literal unions, plus new WAS edge-case unit tests in `tests/test_profile_summary.py` (zero vs null WAS, mixed missing rows, numeric `geoid20` serialization).
> 
> Refactors mobile Playwright specs to centralize API mocking and deterministic UI waits in `frontend/e2e/helpers.ts`, replacing `waitForTimeout` with map-stability polling and `transitionend`-based bottom-sheet waits; also tweaks Replit setup (`npm ci` on boot/build) and ignores Cursor transient state in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82df9c0edf91d8ae9dbc02252adf70ced1497837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->