### PR TITLE
Feature/was analytics followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,17 @@ The Walkable Accessibility Score (WAS) 2019 snapshot is loaded into a second tab
    ```bash
    python scripts/load_walkable_accessibility_score.py
    ```
-4. Validate both tables:
+4. Validate both tables and summarize WAS coverage / bucket distribution:
    ```bash
    python scripts/validate_schema.py
+   python scripts/summarize_was_distribution.py
    ```
+
+The 2019 load observed in the shared database contains 215,831 WAS rows, with
+199,388 direct matches to `national_walkability_index.geoid20` (92.38% naive
+join rate). Amenity Richness uses rounded WAS cutoffs of 10 and 20: the live
+distribution has median 8.45 and upper quartile 21.19, so these are practical
+interpretation breakpoints rather than exact quartiles.
 
 **Connecting from your laptop vs. a managed runtime:** if your Postgres is hosted on Replit or Neon, the "internal" hostname (e.g. `helium`) does not resolve off-platform. Use the external/public URL from the Neon console or Replit's "External URL" setting when running the loader locally, or run the loader from within the Replit environment where the internal hostname does resolve.
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ The Walkable Accessibility Score (WAS) 2019 snapshot is loaded into a second tab
    python scripts/summarize_was_distribution.py
    ```
 
-The 2019 load observed in the shared database contains 215,831 WAS rows, with
-199,388 direct matches to `national_walkability_index.geoid20` (92.38% naive
-join rate). Amenity Richness uses rounded WAS cutoffs of 10 and 20: the live
-distribution has median 8.45 and upper quartile 21.19, so these are practical
-interpretation breakpoints rather than exact quartiles.
+The summary script reports the current WAS row count, direct NWI join rate,
+score distribution, and Amenity Richness bucket counts for the connected
+database. Amenity Richness uses rounded WAS cutoffs of 10 and 20 as practical
+interpretation breakpoints; see `docs/sessions/active/2026-04-17-was-integration.md`
+for the shared database values observed during the WAS analytics follow-up.
 
 **Connecting from your laptop vs. a managed runtime:** if your Postgres is hosted on Replit or Neon, the "internal" hostname (e.g. `helium`) does not resolve off-platform. Use the external/public URL from the Neon console or Replit's "External URL" setting when running the loader locally, or run the loader from within the Replit environment where the internal hostname does resolve.
 
@@ -226,6 +226,7 @@ For fuller testing notes, see [`docs/TESTING.md`](docs/TESTING.md).
 
 - Backend tests: run `pytest`. The Python tests use mocks and do not require a live database connection. See `tests/README.md` for backend details.
 - Frontend tests: run `cd frontend && npm run test:run` for unit tests and `npm run e2e:run` for Playwright coverage.
+  `jsdom` is pinned to `26.1.0` because the current Node `20.18.2` runtime cannot run `jsdom@28`'s transitive `require(ESM)` path.
 - Python lint: run `python -m ruff check --no-cache api services scripts tests`.
 - Frontend typecheck and lint: run `cd frontend && npx tsc --noEmit && npm run lint`.
 - Schema validation: run `python scripts/validate_schema.py`.

--- a/docs/dev_notes/feedback.md
+++ b/docs/dev_notes/feedback.md
@@ -1,3 +1,5 @@
 - 2026-04-26-dwight: What do the colors mean?  What do the abbreviations mean like NWI? When I change the radius it did not update automatically. I had to reload the page.
 
 - 2026-04-26-stephen: It’s very abstract. The metrics don’t mean anything to me. I’d want to know “walking time to nearest grocery store” or “number of restaurants within a 15 minute walk”.
+
+- 2026-04-26-grant: Overall, I think it's kind of hard to understand what's going on in the app. I think it needs a clearer purpose and value proposition. Need to think this through

--- a/docs/dev_notes/feedback.md
+++ b/docs/dev_notes/feedback.md
@@ -1,0 +1,3 @@
+- 2026-04-26-dwight: What do the colors mean?  What do the abbreviations mean like NWI? When I change the radius it did not update automatically. I had to reload the page.
+
+- 2026-04-26-stephen: It’s very abstract. The metrics don’t mean anything to me. I’d want to know “walking time to nearest grocery store” or “number of restaurants within a 15 minute walk”.

--- a/docs/sessions/active/2026-04-17-was-integration.md
+++ b/docs/sessions/active/2026-04-17-was-integration.md
@@ -95,3 +95,15 @@ From `docs/sessions/backlog/2026-02-14-adding-in-walkability-accessibility-score
 - Task 4: Historical Stability Trend (requires loading 1997+ years)
 - Task 5: Update Upgrade Potential logic to require WAS improvement
 - Plus the deferred "fun" visualizations: Hollow Neighborhood scatter view, temporal before/after swipe, radar chart for Compare.
+
+### 2026-04-26 — WAS analytics follow-up
+
+- Created branch `feature/was-analytics-followup`.
+- Real database validation is complete: `python scripts/validate_schema.py` passes with both `national_walkability_index` and `walkable_accessibility_score` present.
+- Added `scripts/summarize_was_distribution.py` for repeatable read-only checks after WAS loads.
+- Current shared DB summary: 215,831 WAS rows, 215,831 distinct GEOIDs, 199,388 direct NWI matches, 92.38% naive join rate.
+- Observed WAS 2019 distribution: min 0.00, p25 0.50, median 8.45, p75 21.19, p90 26.87, max 29.62.
+- Amenity Richness thresholds remain at 10 and 20. Those cutoffs are rounded interpretation breakpoints near the live median / upper quartile, not exact quartiles.
+- Added a Dashboard `NWI vs WAS` tab that visualizes per-block-group agreement/divergence between NWI and WAS, including Hollow Neighborhood quadrant counts.
+- Pinned frontend `jsdom` to `26.1.0` because the current Node runtime (`v20.18.2`) cannot run `jsdom@28`'s transitive `require(ESM)` dependency path.
+- Verification: `python -m ruff check --no-cache api services scripts tests`, `pytest` (137 passed), `cd frontend && npm run typecheck`, `cd frontend && npm run lint`, `cd frontend && npm run test:run` (92 passed), `npm audit --omit=dev` (0 production vulnerabilities).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,19 +29,12 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
-        "jsdom": "^28.0.0",
+        "jsdom": "^26.1.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
         "vitest": "^4.0.18"
       }
-    },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -51,59 +44,25 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.0.tgz",
-      "integrity": "sha512-tJHMAFJ9ooEm8iSiguVqodoEQLBvvcnImz43u0R58m03SMUQENIvXWrN1slb/aiZrC9+X/bXbNWzsrZen9lrgA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -398,9 +357,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -414,13 +373,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -434,17 +393,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -458,21 +417,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.1",
-        "@csstools/css-calc": "^3.0.0"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -486,33 +445,16 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0"
-    },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -526,7 +468,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1126,24 +1068,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
-      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2468,16 +2392,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2652,20 +2566,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2674,29 +2574,17 @@
       "license": "MIT"
     },
     "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -2828,17 +2716,17 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -3378,16 +3266,16 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.6.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -3416,6 +3304,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3542,35 +3443,35 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
-      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.7.6",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^5.3.7",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.20.0",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -3721,13 +3622,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3788,6 +3682,13 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3866,9 +3767,9 @@
       }
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4209,16 +4110,6 @@
         "redux": "^5.0.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -4279,6 +4170,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -4466,49 +4371,49 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.23"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^7.0.5"
+        "tldts": "^6.1.32"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4573,16 +4478,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4831,38 +4726,51 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       }
     },
-    "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
-      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -4906,6 +4814,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "jsdom": "^28.0.0",
+    "jsdom": "^26.1.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1356,6 +1356,46 @@
   margin-top: 0;
 }
 
+.nwi-was-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.nwi-was-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #0f172a;
+  font-size: 0.8rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+}
+
+.nwi-was-tooltip strong {
+  font-size: 0.82rem;
+}
+
+.nwi-was-empty {
+  padding: 1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #475569;
+}
+
+.nwi-was-empty p {
+  margin: 0;
+}
+
+.nwi-was-empty p + p {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+}
+
 @media (max-width: 900px) {
   .correlation-header {
     flex-direction: column;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1396,6 +1396,14 @@
   font-size: 0.85rem;
 }
 
+.nwi-was-color-note {
+  margin: -0.2rem 0 0 0;
+  color: #64748b;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  text-align: center;
+}
+
 @media (max-width: 900px) {
   .correlation-header {
     flex-direction: column;

--- a/frontend/src/components/dashboard/NwiWasScatterChart.test.tsx
+++ b/frontend/src/components/dashboard/NwiWasScatterChart.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { NwiWasScatterChart } from "./NwiWasScatterChart";
+import type { BlockGroupFeature, NwiSummaryResponse } from "../../types/api";
+
+vi.mock("recharts", () => ({
+  CartesianGrid: () => null,
+  ReferenceLine: () => null,
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  Scatter: ({ name }: { name: string }) => <div data-testid="scatter-series">{name}</div>,
+  ScatterChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+function blockGroup(overrides: Partial<BlockGroupFeature>): BlockGroupFeature {
+  return {
+    geoid20: "bg-1",
+    natwalkind: 12,
+    d2a_ranked: null,
+    d2b_ranked: null,
+    d3b_ranked: null,
+    d4a_ranked: null,
+    was_2019: 8,
+    geometry: { type: "Point", coordinates: [-71, 42] },
+    ...overrides,
+  };
+}
+
+function summary(blockGroups: BlockGroupFeature[]): NwiSummaryResponse {
+  return {
+    schema_version: "1",
+    origin: { lat: 42.36, lon: -71.06, label: "Cambridge, MA" },
+    selected_radius_miles: 0.5,
+    search_radius_miles: 1,
+    min_delta: 2,
+    counts: { selected_block_groups: blockGroups.length, context_block_groups: blockGroups.length },
+    nwi: { mean: 12, min: 8, max: 16, spread: 8 },
+    was: { mean: 8, min: 2, max: 18, spread: 16 },
+    components: {
+      employment_housing_mix_rank_mean: null,
+      employment_type_diversity_rank_mean: null,
+      intersection_density_rank_mean: null,
+      transit_proximity_rank_mean_proxy: null,
+    },
+    metrics: {
+      everyday_convenience: 12,
+      variation: 2,
+      transit_viability: 10,
+    },
+    amenity_richness: { value: 8, label: "Destination Sparse" },
+    upgrade_potential: {
+      found: false,
+      candidates: [],
+      selected_mean_nwi: 12,
+      message: "No improvement found.",
+    },
+    walkable_island: { is_island: false, label: null, high_threshold: 15.26, low_threshold: 10.51 },
+    hollow_neighborhood: {
+      is_hollow: true,
+      label: "Hollow Neighborhood",
+      nwi_threshold: 13,
+      was_threshold: 10,
+    },
+    block_groups: blockGroups,
+  };
+}
+
+describe("NwiWasScatterChart", () => {
+  it("shows quadrant counts and hollow candidate count", () => {
+    render(
+      <NwiWasScatterChart
+        summary={summary([
+          blockGroup({ natwalkind: 15, was_2019: 20 }),
+          blockGroup({ natwalkind: 15, was_2019: 5 }),
+          blockGroup({ natwalkind: 8, was_2019: 20 }),
+          blockGroup({ natwalkind: 8, was_2019: 5 }),
+        ])}
+      />
+    );
+
+    expect(screen.getByText("NWI vs Walkable Accessibility Score")).toBeInTheDocument();
+    expect(screen.getByText("Hollow candidates")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("Form + destinations: 1")).toBeInTheDocument();
+    expect(screen.getByText("Hollow: 1")).toBeInTheDocument();
+    expect(screen.getByText("Destinations, lower NWI: 1")).toBeInTheDocument();
+    expect(screen.getByText("Sparse, lower NWI: 1")).toBeInTheDocument();
+  });
+
+  it("renders an unavailable state when block groups lack WAS coverage", () => {
+    render(<NwiWasScatterChart summary={summary([blockGroup({ was_2019: null })])} />);
+
+    expect(screen.getByText("WAS data is unavailable for the selected block groups.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/NwiWasScatterChart.test.tsx
+++ b/frontend/src/components/dashboard/NwiWasScatterChart.test.tsx
@@ -83,13 +83,15 @@ describe("NwiWasScatterChart", () => {
       />
     );
 
-    expect(screen.getByText("NWI vs Walkable Accessibility Score")).toBeInTheDocument();
+    expect(screen.getByText("Walkability vs Amenities")).toBeInTheDocument();
+    expect(screen.getByText(/National Walkability Index \(NWI\) measures built form/)).toBeInTheDocument();
     expect(screen.getByText("Hollow candidates")).toBeInTheDocument();
     expect(screen.getByText("1")).toBeInTheDocument();
-    expect(screen.getByText("Form + destinations: 1")).toBeInTheDocument();
+    expect(screen.getByText("Higher NWI, more amenities: 1")).toBeInTheDocument();
     expect(screen.getByText("Hollow: 1")).toBeInTheDocument();
-    expect(screen.getByText("Destinations, lower NWI: 1")).toBeInTheDocument();
+    expect(screen.getByText("More amenities, lower NWI: 1")).toBeInTheDocument();
     expect(screen.getByText("Sparse, lower NWI: 1")).toBeInTheDocument();
+    expect(screen.getByText(/Colors group block groups/)).toBeInTheDocument();
   });
 
   it("renders an unavailable state when block groups lack WAS coverage", () => {

--- a/frontend/src/components/dashboard/NwiWasScatterChart.tsx
+++ b/frontend/src/components/dashboard/NwiWasScatterChart.tsx
@@ -1,0 +1,189 @@
+/**
+ * NWI vs WAS scatter plot: compares built-form walkability with destination access.
+ */
+
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { NwiSummaryResponse } from "../../types/api";
+import {
+  buildNwiWasPoints,
+  countNwiWasQuadrants,
+  DEFAULT_HIGH_NWI_THRESHOLD,
+  DEFAULT_LOW_WAS_THRESHOLD,
+  NWI_WAS_QUADRANT_INFO,
+  type NwiWasPoint,
+  type NwiWasQuadrant,
+} from "../../lib/nwiWasAnalytics";
+import { CHART_HEIGHTS, CHART_LAYOUT_PRESETS, NWI_DOMAIN, WAS_DOMAIN } from "../../lib/chartConfig";
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
+
+interface NwiWasScatterChartProps {
+  summary: NwiSummaryResponse;
+}
+
+interface ScatterTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload?: NwiWasPoint }>;
+}
+
+const QUADRANT_ORDER: NwiWasQuadrant[] = [
+  "walkableDestinations",
+  "hollowNeighborhood",
+  "destinationRichLowerNwi",
+  "sparseLowerNwi",
+];
+const { margin: NWI_WAS_CHART_MARGINS, axis: NWI_WAS_AXIS } = CHART_LAYOUT_PRESETS.nwiWas;
+
+function formatThreshold(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+}
+
+function NwiWasTooltip({ active, payload }: ScatterTooltipProps) {
+  if (!active || !payload?.[0]?.payload) {
+    return null;
+  }
+
+  const point = payload[0].payload;
+  const info = NWI_WAS_QUADRANT_INFO[point.quadrant];
+
+  return (
+    <div className="nwi-was-tooltip">
+      <strong>{point.geoid20 ?? "Block group"}</strong>
+      <span>{info.label}</span>
+      <span>NWI: {point.nwi.toFixed(2)}</span>
+      <span>WAS: {point.was.toFixed(2)}</span>
+    </div>
+  );
+}
+
+export function NwiWasScatterChart({ summary }: NwiWasScatterChartProps) {
+  const highNwiThreshold = summary.hollow_neighborhood?.nwi_threshold ?? DEFAULT_HIGH_NWI_THRESHOLD;
+  const lowWasThreshold = summary.hollow_neighborhood?.was_threshold ?? DEFAULT_LOW_WAS_THRESHOLD;
+  const thresholds = useMemo(
+    () => ({ highNwiThreshold, lowWasThreshold }),
+    [highNwiThreshold, lowWasThreshold]
+  );
+  const points = useMemo(() => buildNwiWasPoints(summary.block_groups, thresholds), [summary.block_groups, thresholds]);
+  const counts = useMemo(() => countNwiWasQuadrants(points), [points]);
+  const series = useMemo(
+    () =>
+      QUADRANT_ORDER.map((quadrant) => ({
+        quadrant,
+        points: points.filter((point) => point.quadrant === quadrant),
+      })),
+    [points]
+  );
+  const hollowCount = counts.hollowNeighborhood;
+
+  if (points.length === 0) {
+    return (
+      <div className="nwi-was-empty">
+        <p>WAS data is unavailable for the selected block groups.</p>
+        <p>Load the WAS table or choose an area with WAS coverage to compare NWI and destination access.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ChartErrorBoundary chartName="NWI vs WAS Scatter Chart">
+      <div className="nwi-was-chart">
+        <div className="correlation-header">
+          <div className="correlation-header__title-group">
+            <p className="correlation-header__eyebrow">Integration analytics</p>
+            <h3>NWI vs Walkable Accessibility Score</h3>
+            <p className="correlation-header__hint">
+              Each point is a selected-radius block group with both NWI and WAS coverage.
+            </p>
+          </div>
+          <div className="correlation-header__metric" aria-live="polite">
+            <span className="correlation-header__metric-label">Hollow candidates</span>
+            <strong className="correlation-header__metric-value">{hollowCount}</strong>
+            <span className="correlation-header__metric-description">
+              High NWI (&gt;= {formatThreshold(thresholds.highNwiThreshold)}) with low WAS (&lt;={" "}
+              {formatThreshold(thresholds.lowWasThreshold)})
+            </span>
+          </div>
+        </div>
+
+        <div className="correlation-chart-container">
+          <ResponsiveContainer
+            width="100%"
+            height={CHART_HEIGHTS.nwiWas}
+            aria-label="Scatter chart comparing NWI and Walkable Accessibility Score"
+          >
+            <ScatterChart margin={NWI_WAS_CHART_MARGINS}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                type="number"
+                dataKey="nwi"
+                name="NWI"
+                domain={NWI_DOMAIN}
+                height={NWI_WAS_AXIS.xAxisHeight}
+                tickMargin={4}
+                tick={{ fontSize: 11, fill: "#6b7280", fontFamily: "inherit" }}
+                label={{
+                  value: "National Walkability Index (1-20)",
+                  position: "insideBottom",
+                  offset: -4,
+                  style: { fontSize: NWI_WAS_AXIS.axisLabelFontSize, fill: "#6b7280", fontFamily: "inherit" },
+                }}
+              />
+              <YAxis
+                type="number"
+                dataKey="was"
+                name="WAS"
+                domain={WAS_DOMAIN}
+                width={NWI_WAS_AXIS.yAxisWidth}
+                tick={{ fontSize: 11, fill: "#6b7280", fontFamily: "inherit" }}
+                label={{
+                  value: "WAS 2019 (0-30)",
+                  angle: -90,
+                  position: "insideLeft",
+                  offset: NWI_WAS_AXIS.yAxisLabelOffset,
+                  style: { fontSize: NWI_WAS_AXIS.axisLabelFontSize, fill: "#6b7280", fontFamily: "inherit" },
+                }}
+              />
+              <ReferenceLine x={thresholds.highNwiThreshold} stroke="#94a3b8" strokeDasharray="4 4" />
+              <ReferenceLine y={thresholds.lowWasThreshold} stroke="#94a3b8" strokeDasharray="4 4" />
+              <Tooltip content={<NwiWasTooltip />} />
+              {series.map(({ quadrant, points: quadrantPoints }) => (
+                <Scatter
+                  key={quadrant}
+                  name={NWI_WAS_QUADRANT_INFO[quadrant].label}
+                  data={quadrantPoints}
+                  fill={NWI_WAS_QUADRANT_INFO[quadrant].color}
+                  isAnimationActive={false}
+                />
+              ))}
+            </ScatterChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="dashboard-chart-legend" aria-label="NWI versus WAS quadrant legend">
+          {QUADRANT_ORDER.map((quadrant) => {
+            const info = NWI_WAS_QUADRANT_INFO[quadrant];
+            return (
+              <span key={quadrant} className="dashboard-chart-legend__item">
+                <span
+                  className="dashboard-chart-legend__swatch"
+                  style={{ backgroundColor: info.color }}
+                  aria-hidden="true"
+                />
+                {info.shortLabel}: {counts[quadrant]}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </ChartErrorBoundary>
+  );
+}

--- a/frontend/src/components/dashboard/NwiWasScatterChart.tsx
+++ b/frontend/src/components/dashboard/NwiWasScatterChart.tsx
@@ -1,5 +1,5 @@
 /**
- * NWI vs WAS scatter plot: compares built-form walkability with destination access.
+ * Walkability vs amenities scatter plot.
  */
 
 import { useMemo } from "react";
@@ -59,8 +59,8 @@ function NwiWasTooltip({ active, payload }: ScatterTooltipProps) {
     <div className="nwi-was-tooltip">
       <strong>{point.geoid20 ?? "Block group"}</strong>
       <span>{info.label}</span>
-      <span>NWI: {point.nwi.toFixed(2)}</span>
-      <span>WAS: {point.was.toFixed(2)}</span>
+      <span>National Walkability Index: {point.nwi.toFixed(2)}</span>
+      <span>Amenity access score: {point.was.toFixed(2)}</span>
     </div>
   );
 }
@@ -94,14 +94,15 @@ export function NwiWasScatterChart({ summary }: NwiWasScatterChartProps) {
   }
 
   return (
-    <ChartErrorBoundary chartName="NWI vs WAS Scatter Chart">
+    <ChartErrorBoundary chartName="Walkability vs Amenities Chart">
       <div className="nwi-was-chart">
         <div className="correlation-header">
           <div className="correlation-header__title-group">
             <p className="correlation-header__eyebrow">Integration analytics</p>
-            <h3>NWI vs Walkable Accessibility Score</h3>
+            <h3>Walkability vs Amenities</h3>
             <p className="correlation-header__hint">
-              Each point is a selected-radius block group with both NWI and WAS coverage.
+              Each point is a block group. National Walkability Index (NWI) measures built form; Walkable
+              Accessibility Score (WAS) measures reachable destinations.
             </p>
           </div>
           <div className="correlation-header__metric" aria-live="polite">
@@ -118,7 +119,7 @@ export function NwiWasScatterChart({ summary }: NwiWasScatterChartProps) {
           <ResponsiveContainer
             width="100%"
             height={CHART_HEIGHTS.nwiWas}
-            aria-label="Scatter chart comparing NWI and Walkable Accessibility Score"
+            aria-label="Scatter chart comparing National Walkability Index and Walkable Accessibility Score"
           >
             <ScatterChart margin={NWI_WAS_CHART_MARGINS}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -131,7 +132,7 @@ export function NwiWasScatterChart({ summary }: NwiWasScatterChartProps) {
                 tickMargin={4}
                 tick={{ fontSize: 11, fill: "#6b7280", fontFamily: "inherit" }}
                 label={{
-                  value: "National Walkability Index (1-20)",
+                  value: "National Walkability Index, NWI (1-20)",
                   position: "insideBottom",
                   offset: -4,
                   style: { fontSize: NWI_WAS_AXIS.axisLabelFontSize, fill: "#6b7280", fontFamily: "inherit" },
@@ -145,7 +146,7 @@ export function NwiWasScatterChart({ summary }: NwiWasScatterChartProps) {
                 width={NWI_WAS_AXIS.yAxisWidth}
                 tick={{ fontSize: 11, fill: "#6b7280", fontFamily: "inherit" }}
                 label={{
-                  value: "WAS 2019 (0-30)",
+                  value: "Walkable Accessibility Score, WAS (0-30)",
                   angle: -90,
                   position: "insideLeft",
                   offset: NWI_WAS_AXIS.yAxisLabelOffset,
@@ -183,6 +184,10 @@ export function NwiWasScatterChart({ summary }: NwiWasScatterChartProps) {
             );
           })}
         </div>
+        <p className="nwi-was-color-note">
+          Colors group block groups by whether they are above or below the NWI and WAS guide lines. The amber group is
+          the Hollow Neighborhood pattern: walkable form with sparse nearby amenities.
+        </p>
       </div>
     </ChartErrorBoundary>
   );

--- a/frontend/src/lib/chartConfig.ts
+++ b/frontend/src/lib/chartConfig.ts
@@ -49,12 +49,18 @@ export const CHART_AXIS = {
 export const NWI_DOMAIN = [0, 20] as const;
 
 /**
+ * WAS score domain (0-30 scale).
+ */
+export const WAS_DOMAIN = [0, 30] as const;
+
+/**
  * Common chart height configurations.
  */
 export const CHART_HEIGHTS = {
   distribution: 320,
   correlation: 300,
   contribution: 280,
+  nwiWas: 320,
 } as const;
 
 export const CHART_LAYOUT_PRESETS = {
@@ -86,6 +92,19 @@ export const CHART_LAYOUT_PRESETS = {
       ...CHART_AXIS,
       yAxisWidth: 64,
       xAxisHeight: 46,
+    },
+  },
+  nwiWas: {
+    margin: {
+      ...CHART_MARGINS,
+      right: 16,
+      left: 54,
+      bottom: 34,
+    },
+    axis: {
+      ...CHART_AXIS,
+      yAxisWidth: 64,
+      xAxisHeight: 52,
     },
   },
 } as const;

--- a/frontend/src/lib/nwiWasAnalytics.test.ts
+++ b/frontend/src/lib/nwiWasAnalytics.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildNwiWasPoints,
+  classifyNwiWasPoint,
+  countNwiWasQuadrants,
+  type NwiWasThresholds,
+} from "./nwiWasAnalytics";
+import type { BlockGroupFeature } from "../types/api";
+
+const thresholds: NwiWasThresholds = {
+  highNwiThreshold: 13,
+  lowWasThreshold: 10,
+};
+
+function blockGroup(overrides: Partial<BlockGroupFeature>): BlockGroupFeature {
+  return {
+    geoid20: "bg-1",
+    natwalkind: 12,
+    d2a_ranked: null,
+    d2b_ranked: null,
+    d3b_ranked: null,
+    d4a_ranked: null,
+    was_2019: 8,
+    geometry: { type: "Point", coordinates: [-71, 42] },
+    ...overrides,
+  };
+}
+
+describe("NWI/WAS analytics", () => {
+  it("classifies each quadrant using NWI and WAS thresholds", () => {
+    expect(classifyNwiWasPoint(15, 20, thresholds)).toBe("walkableDestinations");
+    expect(classifyNwiWasPoint(15, 5, thresholds)).toBe("hollowNeighborhood");
+    expect(classifyNwiWasPoint(8, 20, thresholds)).toBe("destinationRichLowerNwi");
+    expect(classifyNwiWasPoint(8, 5, thresholds)).toBe("sparseLowerNwi");
+  });
+
+  it("builds points only when both NWI and WAS are present", () => {
+    const points = buildNwiWasPoints(
+      [
+        blockGroup({ geoid20: "A", natwalkind: 15, was_2019: 5 }),
+        blockGroup({ geoid20: "B", natwalkind: null, was_2019: 12 }),
+        blockGroup({ geoid20: "C", natwalkind: 12, was_2019: null }),
+      ],
+      thresholds
+    );
+
+    expect(points).toEqual([{ geoid20: "A", nwi: 15, was: 5, quadrant: "hollowNeighborhood" }]);
+  });
+
+  it("counts points by quadrant", () => {
+    const points = buildNwiWasPoints(
+      [
+        blockGroup({ natwalkind: 15, was_2019: 20 }),
+        blockGroup({ natwalkind: 15, was_2019: 5 }),
+        blockGroup({ natwalkind: 8, was_2019: 20 }),
+        blockGroup({ natwalkind: 8, was_2019: 5 }),
+      ],
+      thresholds
+    );
+
+    expect(countNwiWasQuadrants(points)).toEqual({
+      walkableDestinations: 1,
+      hollowNeighborhood: 1,
+      destinationRichLowerNwi: 1,
+      sparseLowerNwi: 1,
+    });
+  });
+});

--- a/frontend/src/lib/nwiWasAnalytics.ts
+++ b/frontend/src/lib/nwiWasAnalytics.ts
@@ -23,8 +23,8 @@ export interface NwiWasPoint {
 
 export const NWI_WAS_QUADRANT_INFO: Record<NwiWasQuadrant, { label: string; shortLabel: string; color: string }> = {
   walkableDestinations: {
-    label: "Walkable form + destinations",
-    shortLabel: "Form + destinations",
+    label: "Higher NWI + more amenities",
+    shortLabel: "Higher NWI, more amenities",
     color: "#2563eb",
   },
   hollowNeighborhood: {
@@ -33,12 +33,12 @@ export const NWI_WAS_QUADRANT_INFO: Record<NwiWasQuadrant, { label: string; shor
     color: "#d97706",
   },
   destinationRichLowerNwi: {
-    label: "Destination-rich, lower NWI",
-    shortLabel: "Destinations, lower NWI",
+    label: "More amenities, lower NWI",
+    shortLabel: "More amenities, lower NWI",
     color: "#16a34a",
   },
   sparseLowerNwi: {
-    label: "Low NWI + sparse destinations",
+    label: "Lower NWI + sparse amenities",
     shortLabel: "Sparse, lower NWI",
     color: "#64748b",
   },

--- a/frontend/src/lib/nwiWasAnalytics.ts
+++ b/frontend/src/lib/nwiWasAnalytics.ts
@@ -1,0 +1,98 @@
+import type { BlockGroupFeature } from "../types/api";
+
+export const DEFAULT_HIGH_NWI_THRESHOLD = 13;
+export const DEFAULT_LOW_WAS_THRESHOLD = 10;
+
+export type NwiWasQuadrant =
+  | "walkableDestinations"
+  | "hollowNeighborhood"
+  | "destinationRichLowerNwi"
+  | "sparseLowerNwi";
+
+export interface NwiWasThresholds {
+  highNwiThreshold: number;
+  lowWasThreshold: number;
+}
+
+export interface NwiWasPoint {
+  geoid20: string | null;
+  nwi: number;
+  was: number;
+  quadrant: NwiWasQuadrant;
+}
+
+export const NWI_WAS_QUADRANT_INFO: Record<NwiWasQuadrant, { label: string; shortLabel: string; color: string }> = {
+  walkableDestinations: {
+    label: "Walkable form + destinations",
+    shortLabel: "Form + destinations",
+    color: "#2563eb",
+  },
+  hollowNeighborhood: {
+    label: "Hollow Neighborhood",
+    shortLabel: "Hollow",
+    color: "#d97706",
+  },
+  destinationRichLowerNwi: {
+    label: "Destination-rich, lower NWI",
+    shortLabel: "Destinations, lower NWI",
+    color: "#16a34a",
+  },
+  sparseLowerNwi: {
+    label: "Low NWI + sparse destinations",
+    shortLabel: "Sparse, lower NWI",
+    color: "#64748b",
+  },
+};
+
+export function classifyNwiWasPoint(
+  nwi: number,
+  was: number,
+  thresholds: NwiWasThresholds
+): NwiWasQuadrant {
+  const highNwi = nwi >= thresholds.highNwiThreshold;
+  const lowWas = was <= thresholds.lowWasThreshold;
+
+  if (highNwi && lowWas) {
+    return "hollowNeighborhood";
+  }
+  if (highNwi) {
+    return "walkableDestinations";
+  }
+  if (!lowWas) {
+    return "destinationRichLowerNwi";
+  }
+  return "sparseLowerNwi";
+}
+
+export function buildNwiWasPoints(
+  blockGroups: BlockGroupFeature[],
+  thresholds: NwiWasThresholds
+): NwiWasPoint[] {
+  return blockGroups
+    .filter((blockGroup) => blockGroup.natwalkind != null && blockGroup.was_2019 != null)
+    .map((blockGroup) => {
+      const nwi = blockGroup.natwalkind as number;
+      const was = blockGroup.was_2019 as number;
+      return {
+        geoid20: blockGroup.geoid20,
+        nwi,
+        was,
+        quadrant: classifyNwiWasPoint(nwi, was, thresholds),
+      };
+    });
+}
+
+export function countNwiWasQuadrants(points: NwiWasPoint[]): Record<NwiWasQuadrant, number> {
+  return points.reduce<Record<NwiWasQuadrant, number>>(
+    (counts, point) => {
+      counts[point.quadrant] += 1;
+      return counts;
+    },
+    {
+      walkableDestinations: 0,
+      hollowNeighborhood: 0,
+      destinationRichLowerNwi: 0,
+      sparseLowerNwi: 0,
+    }
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -23,10 +23,11 @@ import { COMPONENT_INFO, formatComponentLabel } from "../lib/componentLabels";
 import { ComponentDistributionChart } from "../components/dashboard/ComponentDistributionChart";
 import { ComponentCorrelationChart } from "../components/dashboard/ComponentCorrelationChart";
 import { ComponentContributionChart } from "../components/dashboard/ComponentContributionChart";
+import { NwiWasScatterChart } from "../components/dashboard/NwiWasScatterChart";
 import { useMemo, useState, type ReactNode } from "react";
 
 const { MIN_RADIUS, MAX_RADIUS, STEP } = EXPLORE_PARAMS;
-type DashboardView = "overview" | "distribution" | "correlation";
+type DashboardView = "overview" | "distribution" | "correlation" | "nwiWas";
 
 function formatScore(value: number | null): string {
   return value == null ? "—" : value.toFixed(2);
@@ -180,6 +181,15 @@ export function Dashboard() {
       >
         Correlation
       </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeView === "nwiWas"}
+        className={`dashboard__tab ${activeView === "nwiWas" ? "dashboard__tab--active" : ""}`}
+        onClick={() => setActiveView("nwiWas")}
+      >
+        NWI vs WAS
+      </button>
     </div>
   );
 
@@ -252,6 +262,34 @@ export function Dashboard() {
           <ComponentCorrelationChart blockGroups={summary.block_groups} />
         </section>
       )}
+
+      {hasData && activeView === "nwiWas" && (
+        <section className="dashboard__section" role="tabpanel" aria-label="NWI versus WAS panel">
+          <h2>NWI vs Amenity Access</h2>
+          <p className="dashboard__section-description">
+            Compare EPA built-form walkability with WAS destination access to spot places where the two signals agree
+            or diverge.
+          </p>
+          <NwiWasScatterChart summary={summary} />
+          <div className="dashboard__chart-help" aria-label="How to read NWI versus WAS">
+            <h3>How to read this chart</h3>
+            <ul>
+              <li>
+                <strong>Upper right:</strong> higher NWI and stronger destination access.
+              </li>
+              <li>
+                <strong>Lower right:</strong> Hollow Neighborhood candidates with walkable form but sparse destinations.
+              </li>
+              <li>
+                <strong>Upper left:</strong> destination-rich areas with lower NWI scores.
+              </li>
+              <li>
+                <strong>Lower left:</strong> lower NWI and sparse destination access.
+              </li>
+            </ul>
+          </div>
+        </section>
+      )}
     </>
   );
 
@@ -261,7 +299,7 @@ export function Dashboard() {
       <p className="dashboard__empty-hint">
         You will see distributions, correlations, and contributions for the four NWI components:
         Employment &amp; Household Mix (D2A), Employment Mix (D2B), Intersection Density (D3B), and Transit
-        Proximity (D4A).
+        Proximity (D4A), plus a WAS comparison when amenity data is available.
       </p>
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -188,7 +188,7 @@ export function Dashboard() {
         className={`dashboard__tab ${activeView === "nwiWas" ? "dashboard__tab--active" : ""}`}
         onClick={() => setActiveView("nwiWas")}
       >
-        NWI vs WAS
+        Walkability vs Amenities
       </button>
     </div>
   );
@@ -265,23 +265,23 @@ export function Dashboard() {
 
       {hasData && activeView === "nwiWas" && (
         <section className="dashboard__section" role="tabpanel" aria-label="NWI versus WAS panel">
-          <h2>NWI vs Amenity Access</h2>
+          <h2>Walkability vs Amenities</h2>
           <p className="dashboard__section-description">
-            Compare EPA built-form walkability with WAS destination access to spot places where the two signals agree
-            or diverge.
+            Compare the EPA National Walkability Index (NWI) with the Walkable Accessibility Score (WAS) to see where
+            street form and nearby amenities tell the same or different stories.
           </p>
           <NwiWasScatterChart summary={summary} />
           <div className="dashboard__chart-help" aria-label="How to read NWI versus WAS">
             <h3>How to read this chart</h3>
             <ul>
               <li>
-                <strong>Upper right:</strong> higher NWI and stronger destination access.
+                <strong>Upper right:</strong> higher NWI and more reachable amenities.
               </li>
               <li>
-                <strong>Lower right:</strong> Hollow Neighborhood candidates with walkable form but sparse destinations.
+                <strong>Lower right:</strong> Hollow Neighborhood candidates with walkable form but sparse amenities.
               </li>
               <li>
-                <strong>Upper left:</strong> destination-rich areas with lower NWI scores.
+                <strong>Upper left:</strong> more amenities with lower NWI scores.
               </li>
               <li>
                 <strong>Lower left:</strong> lower NWI and sparse destination access.

--- a/scripts/summarize_was_distribution.py
+++ b/scripts/summarize_was_distribution.py
@@ -1,0 +1,134 @@
+"""Read-only WAS coverage and distribution summary.
+
+Use after ``load_walkable_accessibility_score.py`` to confirm the table loaded,
+measure direct GEOID overlap with the NWI table, and sanity-check the current
+Amenity Richness buckets against the observed WAS 2019 distribution.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow running as a standalone script from the repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from services.db import get_db_connection  # noqa: E402
+from services.metrics import AMENITY_FULL_THRESHOLD, AMENITY_MODERATE_THRESHOLD  # noqa: E402
+
+
+def _as_float(value: Any) -> float | None:
+    """Convert DB numeric/decimal outputs to float for formatting."""
+    if value is None:
+        return None
+    return float(value)
+
+
+def fetch_was_distribution(conn) -> dict[str, Any]:
+    """Return WAS row counts, NWI join coverage, percentiles, and bucket counts."""
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            WITH joined AS (
+              SELECT w.geoid, w.was_2019, n.geoid20
+              FROM walkable_accessibility_score w
+              LEFT JOIN national_walkability_index n ON n.geoid20 = w.geoid
+              WHERE w.was_2019 IS NOT NULL
+            )
+            SELECT
+              COUNT(*) AS was_rows,
+              COUNT(DISTINCT geoid) AS distinct_geoids,
+              COUNT(geoid20) AS matched_rows,
+              (COUNT(geoid20)::numeric / NULLIF(COUNT(DISTINCT geoid), 0)) * 100 AS join_rate_pct,
+              MIN(was_2019),
+              percentile_cont(0.25) WITHIN GROUP (ORDER BY was_2019),
+              percentile_cont(0.5) WITHIN GROUP (ORDER BY was_2019),
+              percentile_cont(0.75) WITHIN GROUP (ORDER BY was_2019),
+              percentile_cont(0.9) WITHIN GROUP (ORDER BY was_2019),
+              MAX(was_2019),
+              COUNT(*) FILTER (WHERE was_2019 >= %s) AS full_count,
+              COUNT(*) FILTER (WHERE was_2019 >= %s AND was_2019 < %s) AS moderate_count,
+              COUNT(*) FILTER (WHERE was_2019 < %s) AS sparse_count
+            FROM joined;
+            """,
+            (
+                AMENITY_FULL_THRESHOLD,
+                AMENITY_MODERATE_THRESHOLD,
+                AMENITY_FULL_THRESHOLD,
+                AMENITY_MODERATE_THRESHOLD,
+            ),
+        )
+        row = cursor.fetchone()
+
+    return {
+        "was_rows": int(row[0] or 0),
+        "distinct_geoids": int(row[1] or 0),
+        "matched_rows": int(row[2] or 0),
+        "join_rate_pct": _as_float(row[3]),
+        "min": _as_float(row[4]),
+        "p25": _as_float(row[5]),
+        "median": _as_float(row[6]),
+        "p75": _as_float(row[7]),
+        "p90": _as_float(row[8]),
+        "max": _as_float(row[9]),
+        "full_count": int(row[10] or 0),
+        "moderate_count": int(row[11] or 0),
+        "sparse_count": int(row[12] or 0),
+    }
+
+
+def _format_number(value: float | None, digits: int = 2) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.{digits}f}"
+
+
+def format_summary(summary: dict[str, Any]) -> str:
+    """Format the distribution summary for operator-facing CLI output."""
+    total = summary["was_rows"] or 0
+
+    def pct(count: int) -> str:
+        if total == 0:
+            return "n/a"
+        return f"{(count / total) * 100:.1f}%"
+
+    lines = [
+        "WAS DISTRIBUTION SUMMARY (read-only)",
+        "=" * 48,
+        f"WAS rows:             {summary['was_rows']:,}",
+        f"Distinct GEOIDs:      {summary['distinct_geoids']:,}",
+        f"NWI-matched rows:     {summary['matched_rows']:,}",
+        f"Naive join rate:      {_format_number(summary['join_rate_pct'])}%",
+        "",
+        "WAS 2019 distribution (0-30 scale)",
+        f"min / p25 / median:  {_format_number(summary['min'])} / {_format_number(summary['p25'])} / {_format_number(summary['median'])}",
+        f"p75 / p90 / max:     {_format_number(summary['p75'])} / {_format_number(summary['p90'])} / {_format_number(summary['max'])}",
+        "",
+        "Amenity Richness buckets using current thresholds",
+        f"Full Amenity Access (>= {AMENITY_FULL_THRESHOLD:g}):      {summary['full_count']:,} ({pct(summary['full_count'])})",
+        f"Moderate Amenity Access ({AMENITY_MODERATE_THRESHOLD:g}-{AMENITY_FULL_THRESHOLD:g}): {summary['moderate_count']:,} ({pct(summary['moderate_count'])})",
+        f"Destination Sparse (< {AMENITY_MODERATE_THRESHOLD:g}):     {summary['sparse_count']:,} ({pct(summary['sparse_count'])})",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    conn = None
+    try:
+        conn = get_db_connection()
+        summary = fetch_was_distribution(conn)
+    except Exception as exc:
+        print(f"ERROR: WAS distribution summary failed: {exc}")
+        return 1
+    finally:
+        if conn is not None:
+            conn.close()
+
+    print(format_summary(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -10,8 +10,14 @@ The WAS table is treated as optional: if missing, we print a warning but exit 0
 so developers can run the app before the WAS loader has been invoked.
 """
 import sys
+from pathlib import Path
 
-from services.db import get_db_connection
+# Allow running as a standalone script from the repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from services.db import get_db_connection  # noqa: E402
 
 NWI_TABLE = "national_walkability_index"
 NWI_COLUMNS = {

--- a/services/metrics.py
+++ b/services/metrics.py
@@ -19,8 +19,9 @@ import pandas as pd
 DEFAULT_ISLAND_HIGH_THRESHOLD = 15.26
 DEFAULT_ISLAND_LOW_THRESHOLD = 10.51
 
-# Amenity Richness labels derived from the WAS 0-30 scale. Rough quartiles;
-# may be refined after we see the real distribution in production data.
+# Amenity Richness labels derived from the WAS 0-30 scale. After the 2019
+# production load, 10 sits just above the median (8.45) and 20 sits near the
+# upper quartile (21.19), giving rounded, interpretable breakpoints.
 AMENITY_FULL_THRESHOLD = 20.0
 AMENITY_MODERATE_THRESHOLD = 10.0
 

--- a/tests/test_summarize_was_distribution.py
+++ b/tests/test_summarize_was_distribution.py
@@ -1,4 +1,47 @@
-from scripts.summarize_was_distribution import format_summary
+from unittest.mock import MagicMock, Mock
+
+from scripts.summarize_was_distribution import fetch_was_distribution, format_summary
+
+
+def test_fetch_was_distribution_maps_sql_row_to_summary_dict():
+    cursor = Mock()
+    cursor.fetchone.return_value = (
+        215831,
+        215831,
+        199388,
+        92.38,
+        0.0,
+        0.5,
+        8.45,
+        21.19,
+        26.87,
+        29.62,
+        59318,
+        41816,
+        114697,
+    )
+    conn = Mock()
+    conn.cursor.return_value = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    summary = fetch_was_distribution(conn)
+
+    assert summary == {
+        "was_rows": 215831,
+        "distinct_geoids": 215831,
+        "matched_rows": 199388,
+        "join_rate_pct": 92.38,
+        "min": 0.0,
+        "p25": 0.5,
+        "median": 8.45,
+        "p75": 21.19,
+        "p90": 26.87,
+        "max": 29.62,
+        "full_count": 59318,
+        "moderate_count": 41816,
+        "sparse_count": 114697,
+    }
+    cursor.execute.assert_called_once()
 
 
 def test_format_summary_includes_join_rate_distribution_and_bucket_counts():

--- a/tests/test_summarize_was_distribution.py
+++ b/tests/test_summarize_was_distribution.py
@@ -1,0 +1,26 @@
+from scripts.summarize_was_distribution import format_summary
+
+
+def test_format_summary_includes_join_rate_distribution_and_bucket_counts():
+    summary = {
+        "was_rows": 215831,
+        "distinct_geoids": 215831,
+        "matched_rows": 199388,
+        "join_rate_pct": 92.38,
+        "min": 0.0,
+        "p25": 0.5,
+        "median": 8.45,
+        "p75": 21.19,
+        "p90": 26.87,
+        "max": 29.62,
+        "full_count": 59318,
+        "moderate_count": 41816,
+        "sparse_count": 114697,
+    }
+
+    output = format_summary(summary)
+
+    assert "Naive join rate:      92.38%" in output
+    assert "min / p25 / median:  0.00 / 0.50 / 8.45" in output
+    assert "Full Amenity Access (>= 20):      59,318 (27.5%)" in output
+    assert "Destination Sparse (< 10):     114,697 (53.1%)" in output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: adds a new dashboard visualization and analytics helpers plus a new DB-querying validation script, and changes frontend test dependencies by pinning `jsdom`, which could affect CI/test behavior.
> 
> **Overview**
> Adds a new Dashboard view, **“Walkability vs Amenities”**, that plots block groups on an NWI-vs-WAS scatter chart with quadrant counts, Hollow Neighborhood guide lines, tooltips, and an explicit empty state when WAS coverage is missing.
> 
> Introduces `scripts/summarize_was_distribution.py` (with tests) to report WAS row counts, NWI join rate, distribution percentiles, and Amenity Richness bucket counts, and updates docs to include this post-load validation step and clarify the 10/20 WAS thresholds.
> 
> Pins frontend `jsdom` to `26.1.0` (and updates the lockfile) to keep the test runtime compatible with the current Node 20.18.2 environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b9c49d2f377973ba38a27cf12fd437b6577385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->