### PR TITLE
Implement WAS-aware Upgrade Potential logic and update related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ The app has four main routes:
 The main controls are:
 - `Radius`: the area shown around the selected location.
 - `Search radius`: the optional surrounding area used to look for nearby better-scoring block groups.
-- `Minimum NWI improvement delta`: the threshold for flagging better nearby candidates.
+- `Minimum NWI improvement delta`: the threshold for flagging nearby candidates with better EPA walkability.
+- `Upgrade Potential`: candidates must improve both EPA walkability (NWI) and amenities (WAS) by at least +2.0 WAS points when WAS data is available. If WAS is unavailable for that comparison, the app falls back to the older NWI-only rule and labels the result as NWI-only.
 
 ## API (FastAPI)
 ### Run locally

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -16,6 +16,7 @@ AmenityRichnessLabel = Literal[
     "Unavailable",
 ]
 HollowNeighborhoodLabel = Literal["Hollow Neighborhood"]
+UpgradePotentialMode = Literal["nwi_and_was", "nwi_only"]
 
 
 class HealthResponse(BaseModel):
@@ -96,14 +97,19 @@ class BlockGroupFeature(BaseModel):
 class UpgradeCandidate(BaseModel):
     geoid20: str | None
     natwalkind: float | None
+    was_2019: float | None = None
     dist_miles: float | None
     delta_nwi: float | None
+    delta_was: float | None = None
 
 
 class UpgradePotential(BaseModel):
     found: bool
     candidates: list[UpgradeCandidate]
     selected_mean_nwi: float | None
+    selected_mean_was: float | None = None
+    min_delta_was: float = 2.0
+    mode: UpgradePotentialMode = "nwi_only"
     message: str
 
 

--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -42,6 +42,12 @@ For `NwiSummaryResponse`:
 - Non-core endpoints may be added/removed during internal development.
 - Internal implementation details are free to change if stable items above hold.
 
+### Upgrade Potential semantics
+
+`upgrade_potential` is evolving while WAS analytics are internal. Current semantics:
+- `mode="nwi_and_was"` means candidates cleared the NWI delta threshold and improved `was_2019` by at least `min_delta_was` points.
+- `mode="nwi_only"` means WAS could not be evaluated for the comparison, so candidates use the legacy NWI-only rule and clients should label that fallback explicitly.
+
 ## Change Policy (Shipping Mode)
 
 - Small additive changes: proceed directly.

--- a/docs/sessions/active/2026-04-17-was-integration.md
+++ b/docs/sessions/active/2026-04-17-was-integration.md
@@ -93,7 +93,7 @@ and the [GitHub repo](https://github.com/kcredit/Walkable-Accessibility-Score):
 
 From `docs/sessions/backlog/2026-02-14-adding-in-walkability-accessibility-score.md`:
 - Task 4: Historical Stability Trend (requires loading 1997+ years)
-- Task 5: Update Upgrade Potential logic to require WAS improvement
+- Task 5: Update Upgrade Potential logic to require WAS improvement — completed on branch `feature/was-aware-upgrade-potential`
 - Plus the deferred "fun" visualizations: Hollow Neighborhood scatter view, temporal before/after swipe, radar chart for Compare.
 
 ### 2026-04-26 — WAS analytics follow-up
@@ -107,3 +107,13 @@ From `docs/sessions/backlog/2026-02-14-adding-in-walkability-accessibility-score
 - Added a Dashboard `NWI vs WAS` tab that visualizes per-block-group agreement/divergence between NWI and WAS, including Hollow Neighborhood quadrant counts.
 - Pinned frontend `jsdom` to `26.1.0` because the current Node runtime (`v20.18.2`) cannot run `jsdom@28`'s transitive `require(ESM)` dependency path.
 - Verification: `python -m ruff check --no-cache api services scripts tests`, `pytest` (137 passed), `cd frontend && npm run typecheck`, `cd frontend && npm run lint`, `cd frontend && npm run test:run` (92 passed), `npm audit --omit=dev` (0 production vulnerabilities).
+
+### 2026-04-26 — WAS-aware Upgrade Potential
+
+- Created branch `feature/was-aware-upgrade-potential`.
+- Task 5 direction: Upgrade Potential should prefer nearby candidates that improve both EPA walkability (NWI) and amenities (WAS).
+- Product decision: keep the existing NWI delta threshold and require at least +2.0 WAS points when WAS data is available.
+- Fallback decision: when WAS cannot be evaluated, keep the legacy NWI-only behavior but label the result as `nwi_only` so the UI does not imply amenity improvement.
+- Implementation: `upgrade_potential.mode` now reports `nwi_and_was` or `nwi_only`; candidates include `was_2019` and `delta_was` when available.
+- Review refinements: mixed candidate WAS coverage now falls back to `nwi_only` instead of silently dropping null-WAS candidates; `UpgradePotentialMode` is covered by the Python/TypeScript literal contract test; schema marker bumped to `2026-04-26-was-aware-upgrade-potential`; Explore table copy has direct test coverage.
+- Verification: `python -m ruff check --no-cache api services scripts tests`, `pytest` (143 passed), `cd frontend && npm run typecheck`, `cd frontend && npm run lint`, `cd frontend && npm run test:run` (95 passed).

--- a/frontend/src/components/CompareTable.test.tsx
+++ b/frontend/src/components/CompareTable.test.tsx
@@ -91,10 +91,34 @@ describe("CompareTable", () => {
     rerender(<CompareTable summaryA={summaryA} summaryB={summaryBWithUpgrade} />);
     
     expect(screen.getByText("None")).toBeInTheDocument(); // A
-    expect(screen.getByText("+2.5 available")).toBeInTheDocument(); // B
+    expect(screen.getByText("+2.5 NWI (NWI-only)")).toBeInTheDocument(); // B
     
     // Should NOT say "Same"
     expect(screen.queryByText("Same")).not.toBeInTheDocument();
+  });
+
+  it("shows both NWI and WAS gains for WAS-aware upgrade potential", () => {
+    const summaryBWithUpgrade = createMockSummary("City B", { everyday: 12, transit: 5, variation: 1.5 }, true);
+    summaryBWithUpgrade.upgrade_potential = {
+      ...summaryBWithUpgrade.upgrade_potential,
+      mode: "nwi_and_was",
+      selected_mean_was: 10,
+      min_delta_was: 2,
+      candidates: [
+        {
+          geoid20: "123",
+          natwalkind: 15,
+          was_2019: 13,
+          dist_miles: 1.5,
+          delta_nwi: 2.5,
+          delta_was: 3,
+        },
+      ],
+    };
+
+    render(<CompareTable summaryA={summaryA} summaryB={summaryBWithUpgrade} />);
+
+    expect(screen.getByText("+2.5 NWI, +3.0 WAS")).toBeInTheDocument();
   });
 
   it("renders null when props are missing", () => {

--- a/frontend/src/components/CompareTable.tsx
+++ b/frontend/src/components/CompareTable.tsx
@@ -32,8 +32,11 @@ export function CompareTable({ summaryA, summaryB }: CompareTableProps) {
     if (upgrade_potential?.found && upgrade_potential.candidates?.length) {
         const best = upgrade_potential.candidates[0];
         if (best.delta_nwi != null) {
-            const d = best.delta_nwi;
-            return `${d > 0 ? '+' : ''}${d.toFixed(1)} available`;
+            const nwiDelta = `${best.delta_nwi > 0 ? '+' : ''}${best.delta_nwi.toFixed(1)} NWI`;
+            if (upgrade_potential.mode === "nwi_and_was" && best.delta_was != null) {
+              return `${nwiDelta}, +${best.delta_was.toFixed(1)} WAS`;
+            }
+            return `${nwiDelta} (NWI-only)`;
         }
         return "Found";
     }
@@ -90,7 +93,7 @@ export function CompareTable({ summaryA, summaryB }: CompareTableProps) {
           <tr className="row-upgrade">
             <td className="cell-metric">
                 <div className="metric-label">Upgrade Potential</div>
-                <div className="metric-desc">Best nearby improvement</div>
+                <div className="metric-desc">Best nearby NWI + amenity improvement when WAS is available</div>
             </td>
             <td className="cell-val-a" data-label={labelA}>{upgradeA}</td>
             <td className="cell-val-b" data-label={labelB}>{upgradeB}</td>

--- a/frontend/src/components/SummaryCards.test.tsx
+++ b/frontend/src/components/SummaryCards.test.tsx
@@ -72,6 +72,31 @@ describe("SummaryCards", () => {
     expect(screen.getByText("+2.5")).toBeInTheDocument();
   });
 
+  it("labels WAS-aware upgrade candidates with amenity improvement", () => {
+    const summary = minimalSummary({
+      upgrade_potential: {
+        found: true,
+        mode: "nwi_and_was",
+        selected_mean_nwi: 12.5,
+        selected_mean_was: 10,
+        min_delta_was: 2,
+        candidates: [
+          {
+            geoid20: "123",
+            natwalkind: 15,
+            was_2019: 13,
+            dist_miles: 0.3,
+            delta_nwi: 2.5,
+            delta_was: 3,
+          },
+        ],
+        message: "",
+      },
+    });
+    render(<SummaryCards summary={summary} />);
+    expect(screen.getByText("NWI + amenities (+3.0 WAS) · 0.3 mi away")).toBeInTheDocument();
+  });
+
   it("shows amenity richness value and label when WAS data is available", () => {
     const summary = minimalSummary({
       amenity_richness: { value: 17.5, label: "Moderate Amenity Access" },

--- a/frontend/src/components/SummaryCards.tsx
+++ b/frontend/src/components/SummaryCards.tsx
@@ -16,18 +16,22 @@ export function SummaryCards({ summary }: SummaryCardsProps) {
 
   let upgradeVal: string;
   let upgradeCaption: string | null = null;
+  const upgradeMode = upgrade_potential?.mode ?? "nwi_only";
   if (upgrade_potential?.found && upgrade_potential.candidates?.length) {
     const best = upgrade_potential.candidates[0];
     const delta = best?.delta_nwi;
+    const deltaWas = best?.delta_was;
     const dist = best?.dist_miles;
     if (delta != null && dist != null) {
       upgradeVal = delta > 0 ? `+${delta.toFixed(1)}` : `${delta.toFixed(1)}`;
-      upgradeCaption =
-        upgrade_potential.candidates.length > 1
-          ? `Best nearby (${dist.toFixed(1)} mi)`
-          : `${dist.toFixed(1)} mi away`;
+      const modeLabel =
+        upgradeMode === "nwi_and_was" && deltaWas != null
+          ? `NWI + amenities (+${deltaWas.toFixed(1)} WAS)`
+          : "NWI-only";
+      upgradeCaption = `${modeLabel} · ${dist.toFixed(1)} mi away`;
     } else {
       upgradeVal = "Found";
+      upgradeCaption = upgradeMode === "nwi_and_was" ? "NWI + amenities" : "NWI-only";
     }
   } else {
     upgradeVal = upgrade_potential?.message ?? "None found";
@@ -64,7 +68,7 @@ export function SummaryCards({ summary }: SummaryCardsProps) {
         <div className="summary-card__hint">{amenityCaption}</div>
       </div>
 
-      <div className="summary-card" title="Best nearby candidate meeting minimum NWI improvement threshold (default: 2.0 points).">
+      <div className="summary-card" title="Best nearby candidate meeting the minimum EPA walkability (NWI) improvement threshold and, when available, at least +2.0 Walkable Accessibility Score (WAS) points. Falls back to NWI-only when WAS data is unavailable.">
         <div
           className={
             upgradeVal.length > 12

--- a/frontend/src/pages/Explore.test.tsx
+++ b/frontend/src/pages/Explore.test.tsx
@@ -33,7 +33,7 @@ const baseHookState = {
   submit: vi.fn(),
 };
 
-function makeSummary(): NwiSummaryResponse {
+function makeSummary(overrides: Partial<NwiSummaryResponse> = {}): NwiSummaryResponse {
   return {
     schema_version: "1",
     origin: { lat: 41.9484, lon: -87.6553, label: WRIGLEY_FIELD_ADDRESS },
@@ -52,6 +52,7 @@ function makeSummary(): NwiSummaryResponse {
     upgrade_potential: { found: false, candidates: [], selected_mean_nwi: 10, message: "" },
     walkable_island: { is_island: false, label: null, high_threshold: 15.26, low_threshold: 10.51 },
     block_groups: [],
+    ...overrides,
   };
 }
 
@@ -107,5 +108,41 @@ describe("Explore page default preload", () => {
     render(<Explore />);
     await waitFor(() => expect(nwiSummaryByQuery).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(nwiSummaryByQuery).toHaveBeenCalledTimes(2), { timeout: 2500 });
+  });
+
+  it("renders WAS-aware nearby candidate table copy", () => {
+    const summary = makeSummary({
+      upgrade_potential: {
+        found: true,
+        mode: "nwi_and_was",
+        selected_mean_nwi: 10,
+        selected_mean_was: 8,
+        min_delta_was: 2,
+        message: "Found 1 candidate improving NWI and WAS.",
+        candidates: [
+          {
+            geoid20: "170318238011",
+            natwalkind: 14,
+            was_2019: 13,
+            dist_miles: 0.8,
+            delta_nwi: 4,
+            delta_was: 5,
+          },
+        ],
+      },
+    });
+    vi.mocked(useUrlDrivenSearch).mockReturnValue({
+      ...baseHookState,
+      params: { q: WRIGLEY_FIELD_ADDRESS, radius: 0.5 },
+      result: summary,
+    } as never);
+
+    render(<Explore />);
+
+    expect(screen.getByText("Nearby places with better walkability and amenities")).toBeInTheDocument();
+    expect(screen.getByText(/improve both the EPA National Walkability Index/)).toBeInTheDocument();
+    expect(screen.getByText("Amenities (WAS)")).toBeInTheDocument();
+    expect(screen.getByText("WAS Improvement")).toBeInTheDocument();
+    expect(screen.getByText("+5.00")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Explore.tsx
+++ b/frontend/src/pages/Explore.tsx
@@ -232,13 +232,28 @@ export function Explore() {
           {summary.upgrade_potential?.found &&
             summary.upgrade_potential.candidates?.length > 0 && (
               <section className="explore__nearby">
-                <h2>Nearby-better candidates</h2>
+                <h2>
+                  {summary.upgrade_potential.mode === "nwi_and_was"
+                    ? "Nearby places with better walkability and amenities"
+                    : "Nearby places with better EPA walkability (NWI only)"}
+                </h2>
+                <p>
+                  {summary.upgrade_potential.mode === "nwi_and_was"
+                    ? "These block groups improve both the EPA National Walkability Index (NWI) and Walkable Accessibility Score (WAS)."
+                    : "WAS amenity data is unavailable for this comparison, so these candidates use the older NWI-only rule."}
+                </p>
                 <table>
                   <thead>
                     <tr>
                       <th>Block Group ID</th>
-                      <th>NWI Score</th>
+                      <th>EPA Walkability (NWI)</th>
                       <th>NWI Improvement</th>
+                      {summary.upgrade_potential.mode === "nwi_and_was" && (
+                        <>
+                          <th>Amenities (WAS)</th>
+                          <th>WAS Improvement</th>
+                        </>
+                      )}
                       <th>Distance (mi)</th>
                     </tr>
                   </thead>
@@ -248,6 +263,12 @@ export function Explore() {
                         <td>{c.geoid20 ?? "—"}</td>
                         <td>{c.natwalkind != null ? c.natwalkind.toFixed(2) : "—"}</td>
                         <td>{c.delta_nwi != null ? `+${c.delta_nwi.toFixed(2)}` : "—"}</td>
+                        {summary.upgrade_potential.mode === "nwi_and_was" && (
+                          <>
+                            <td>{c.was_2019 != null ? c.was_2019.toFixed(2) : "—"}</td>
+                            <td>{c.delta_was != null ? `+${c.delta_was.toFixed(2)}` : "—"}</td>
+                          </>
+                        )}
                         <td>{c.dist_miles != null ? c.dist_miles.toFixed(2) : "—"}</td>
                       </tr>
                     ))}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -43,6 +43,7 @@ export type AmenityRichnessLabel =
 
 /** Hollow Neighborhood banner label (singleton). */
 export type HollowNeighborhoodLabel = "Hollow Neighborhood";
+export type UpgradePotentialMode = "nwi_and_was" | "nwi_only";
 
 /** Human-readable interpretation of the mean WAS score. */
 export interface AmenityRichness {
@@ -85,14 +86,19 @@ export interface BlockGroupFeature {
 export interface UpgradeCandidate {
   geoid20: string | null;
   natwalkind: number | null;
+  was_2019?: number | null;
   dist_miles: number | null;
   delta_nwi: number | null;
+  delta_was?: number | null;
 }
 
 export interface UpgradePotential {
   found: boolean;
   candidates: UpgradeCandidate[];
   selected_mean_nwi: number | null;
+  selected_mean_was?: number | null;
+  min_delta_was?: number;
+  mode?: UpgradePotentialMode;
   message: string;
 }
 

--- a/services/metrics.py
+++ b/services/metrics.py
@@ -44,6 +44,12 @@ HOLLOW_NEIGHBORHOOD_LABEL = "Hollow Neighborhood"
 DEFAULT_HOLLOW_NWI_THRESHOLD = 13.0
 DEFAULT_HOLLOW_WAS_THRESHOLD = 10.0
 
+# Upgrade Potential keeps the existing NWI threshold from API params, then
+# requires a material WAS gain when WAS data is available for comparison.
+DEFAULT_UPGRADE_WAS_DELTA = 2.0
+UPGRADE_MODE_NWI_AND_WAS = "nwi_and_was"
+UPGRADE_MODE_NWI_ONLY = "nwi_only"
+
 
 def _numeric_series(gdf, column_name: str) -> pd.Series:
     """Return a numeric, NaN-dropped series for a GeoDataFrame column.
@@ -176,19 +182,26 @@ def compute_upgrade_potential(
     min_delta: float,
     top_n: int = 3,
     search_radius_miles: float | None = None,
+    min_delta_was: float = DEFAULT_UPGRADE_WAS_DELTA,
 ) -> dict[str, Any]:
-    """Find nearby block groups with material NWI improvement over selected mean."""
+    """Find nearby block groups with material NWI and, when available, WAS improvement."""
     if top_n <= 0:
         raise ValueError("top_n must be positive")
     if min_delta < 0:
         raise ValueError("min_delta must be non-negative")
+    if min_delta_was < 0:
+        raise ValueError("min_delta_was must be non-negative")
 
     selected_mean_nwi = compute_everyday_convenience(selected_gdf)
+    selected_mean_was = compute_amenity_richness(selected_gdf)
     if selected_mean_nwi is None:
         return {
             "found": False,
             "candidates": [],
             "selected_mean_nwi": None,
+            "selected_mean_was": selected_mean_was,
+            "min_delta_was": float(min_delta_was),
+            "mode": UPGRADE_MODE_NWI_ONLY,
             "message": "No improvement found: selected area has no valid NWI values.",
         }
 
@@ -197,6 +210,9 @@ def compute_upgrade_potential(
             "found": False,
             "candidates": [],
             "selected_mean_nwi": selected_mean_nwi,
+            "selected_mean_was": selected_mean_was,
+            "min_delta_was": float(min_delta_was),
+            "mode": UPGRADE_MODE_NWI_ONLY,
             "message": _no_improvement_message(search_radius_miles),
         }
 
@@ -211,6 +227,9 @@ def compute_upgrade_potential(
             "found": False,
             "candidates": [],
             "selected_mean_nwi": selected_mean_nwi,
+            "selected_mean_was": selected_mean_was,
+            "min_delta_was": float(min_delta_was),
+            "mode": UPGRADE_MODE_NWI_ONLY,
             "message": _no_improvement_message(search_radius_miles),
         }
 
@@ -233,11 +252,41 @@ def compute_upgrade_potential(
             "found": False,
             "candidates": [],
             "selected_mean_nwi": selected_mean_nwi,
+            "selected_mean_was": selected_mean_was,
+            "min_delta_was": float(min_delta_was),
+            "mode": UPGRADE_MODE_NWI_AND_WAS if selected_mean_was is not None else UPGRADE_MODE_NWI_ONLY,
             "message": _no_improvement_message(search_radius_miles),
+        }
+
+    mode = UPGRADE_MODE_NWI_ONLY
+    if selected_mean_was is not None and "was_2019" in candidates.columns:
+        if not pd.api.types.is_numeric_dtype(candidates["was_2019"]):
+            candidates["was_2019"] = pd.to_numeric(candidates["was_2019"], errors="coerce")
+        if candidates["was_2019"].notna().all():
+            mode = UPGRADE_MODE_NWI_AND_WAS
+            candidates["delta_was"] = candidates["was_2019"] - selected_mean_was
+            candidates = candidates[candidates["delta_was"] >= float(min_delta_was)]
+
+    if candidates.empty:
+        return {
+            "found": False,
+            "candidates": [],
+            "selected_mean_nwi": selected_mean_nwi,
+            "selected_mean_was": selected_mean_was,
+            "min_delta_was": float(min_delta_was),
+            "mode": mode,
+            "message": (
+                _no_nwi_was_improvement_message(search_radius_miles)
+                if mode == UPGRADE_MODE_NWI_AND_WAS
+                else _no_improvement_message(search_radius_miles)
+            ),
         }
 
     sort_columns = ["delta_nwi"]
     ascending = [False]
+    if mode == UPGRADE_MODE_NWI_AND_WAS:
+        sort_columns.append("delta_was")
+        ascending.append(False)
     if has_distance:
         sort_columns.append("dist_miles")
         ascending.append(True)
@@ -253,8 +302,10 @@ def compute_upgrade_potential(
             {
                 "geoid20": str(row["geoid20"]) if "geoid20" in row and pd.notna(row["geoid20"]) else None,
                 "natwalkind": _safe_float(row.get("natwalkind")),
+                "was_2019": _safe_float(row.get("was_2019")),
                 "dist_miles": _safe_float(row.get("dist_miles")),
                 "delta_nwi": _safe_float(row.get("delta_nwi")),
+                "delta_was": _safe_float(row.get("delta_was")),
             }
         )
 
@@ -262,7 +313,14 @@ def compute_upgrade_potential(
         "found": True,
         "candidates": candidate_rows,
         "selected_mean_nwi": selected_mean_nwi,
-        "message": f"Found {len(candidate_rows)} improvement candidate(s).",
+        "selected_mean_was": selected_mean_was,
+        "min_delta_was": float(min_delta_was),
+        "mode": mode,
+        "message": (
+            f"Found {len(candidate_rows)} candidate(s) improving NWI and WAS."
+            if mode == UPGRADE_MODE_NWI_AND_WAS
+            else f"Found {len(candidate_rows)} NWI-only improvement candidate(s); WAS data unavailable."
+        ),
     }
 
 
@@ -270,6 +328,12 @@ def _no_improvement_message(search_radius_miles: float | None) -> str:
     if search_radius_miles is None:
         return "No improvement found within the search radius."
     return f"No improvement found within {search_radius_miles:.1f} miles."
+
+
+def _no_nwi_was_improvement_message(search_radius_miles: float | None) -> str:
+    if search_radius_miles is None:
+        return "No candidate improves both EPA walkability (NWI) and amenities (WAS) within the search radius."
+    return f"No candidate improves both EPA walkability (NWI) and amenities (WAS) within {search_radius_miles:.1f} miles."
 
 
 def check_walkable_island(

--- a/services/profile_summary.py
+++ b/services/profile_summary.py
@@ -21,9 +21,10 @@ _log = logging.getLogger(__name__)
 # Bumped again when component scores (d2a, d2b, d3b, d4a) were added to block_groups.
 # Bumped again when WAS 2019 fields (was, amenity_richness, hollow_neighborhood,
 # and per-block-group was_2019) were added.
+# Bumped again when Upgrade Potential added WAS-aware mode and candidate deltas.
 # The API is always forward-compatible (new fields have defaults), so this
 # string is documentary only — the frontend does not gate on it.
-SCHEMA_VERSION = "2026-04-17-was-integration"
+SCHEMA_VERSION = "2026-04-26-was-aware-upgrade-potential"
 
 
 def _validate_coordinates(lat: float, lon: float) -> tuple[float, float]:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,7 +12,10 @@ from services.metrics import (
     DEFAULT_HOLLOW_WAS_THRESHOLD,
     DEFAULT_ISLAND_HIGH_THRESHOLD,
     DEFAULT_ISLAND_LOW_THRESHOLD,
+    DEFAULT_UPGRADE_WAS_DELTA,
     HOLLOW_NEIGHBORHOOD_LABEL,
+    UPGRADE_MODE_NWI_AND_WAS,
+    UPGRADE_MODE_NWI_ONLY,
     amenity_richness_label,
     check_hollow_neighborhood,
     check_walkable_island,
@@ -74,17 +77,17 @@ class TestUpgradePotential:
     def test_compute_upgrade_potential_filters_and_sorts(self):
         selected = _gdf(
             [
-                {"geoid20": "A", "natwalkind": 8.0, "dist_miles": 0.2},
-                {"geoid20": "B", "natwalkind": 10.0, "dist_miles": 0.7},
+                {"geoid20": "A", "natwalkind": 8.0, "was_2019": 8.0, "dist_miles": 0.2},
+                {"geoid20": "B", "natwalkind": 10.0, "was_2019": 10.0, "dist_miles": 0.7},
             ]
         )
         search = _gdf(
             [
-                {"geoid20": "A", "natwalkind": 18.0, "dist_miles": 1.2},  # excluded by geoid
-                {"geoid20": "C", "natwalkind": 11.5, "dist_miles": 1.0},  # delta 2.5
-                {"geoid20": "D", "natwalkind": 13.0, "dist_miles": 2.0},  # delta 4.0
-                {"geoid20": "E", "natwalkind": 15.0, "dist_miles": 6.0},  # outside radius
-                {"geoid20": "F", "natwalkind": 10.1, "dist_miles": 1.5},  # below min_delta
+                {"geoid20": "A", "natwalkind": 18.0, "was_2019": 30.0, "dist_miles": 1.2},  # excluded
+                {"geoid20": "C", "natwalkind": 11.5, "was_2019": 12.0, "dist_miles": 1.0},  # both pass
+                {"geoid20": "D", "natwalkind": 13.0, "was_2019": 14.0, "dist_miles": 2.0},  # both pass
+                {"geoid20": "E", "natwalkind": 15.0, "was_2019": 20.0, "dist_miles": 6.0},  # outside radius
+                {"geoid20": "F", "natwalkind": 10.1, "was_2019": 20.0, "dist_miles": 1.5},  # below NWI
             ]
         )
         result = compute_upgrade_potential(
@@ -97,9 +100,86 @@ class TestUpgradePotential:
 
         assert result["found"] is True
         assert result["selected_mean_nwi"] == 9.0
+        assert result["selected_mean_was"] == 9.0
+        assert result["min_delta_was"] == DEFAULT_UPGRADE_WAS_DELTA
+        assert result["mode"] == UPGRADE_MODE_NWI_AND_WAS
         assert [candidate["geoid20"] for candidate in result["candidates"]] == ["D", "C"]
         assert result["candidates"][0]["delta_nwi"] == 4.0
+        assert result["candidates"][0]["delta_was"] == 5.0
         assert result["candidates"][0]["dist_miles"] == 2.0
+
+    def test_compute_upgrade_potential_rejects_high_nwi_without_was_gain(self):
+        selected = _gdf([{"geoid20": "A", "natwalkind": 10.0, "was_2019": 10.0, "dist_miles": 0.2}])
+        search = _gdf([{"geoid20": "B", "natwalkind": 15.0, "was_2019": 11.0, "dist_miles": 1.0}])
+
+        result = compute_upgrade_potential(
+            selected,
+            search,
+            min_delta=2.0,
+            search_radius_miles=3.0,
+        )
+
+        assert result["found"] is False
+        assert result["mode"] == UPGRADE_MODE_NWI_AND_WAS
+        assert result["candidates"] == []
+        assert result["message"] == (
+            "No candidate improves both EPA walkability (NWI) and amenities (WAS) within 3.0 miles."
+        )
+
+    def test_compute_upgrade_potential_falls_back_to_nwi_only_without_was(self):
+        selected = _gdf([{"geoid20": "A", "natwalkind": 10.0, "dist_miles": 0.2}])
+        search = _gdf([{"geoid20": "B", "natwalkind": 15.0, "dist_miles": 1.0}])
+
+        result = compute_upgrade_potential(
+            selected,
+            search,
+            min_delta=2.0,
+            search_radius_miles=3.0,
+        )
+
+        assert result["found"] is True
+        assert result["mode"] == UPGRADE_MODE_NWI_ONLY
+        assert result["selected_mean_was"] is None
+        assert result["candidates"][0]["geoid20"] == "B"
+        assert result["candidates"][0]["delta_was"] is None
+        assert result["message"] == "Found 1 NWI-only improvement candidate(s); WAS data unavailable."
+
+    def test_compute_upgrade_potential_falls_back_to_nwi_only_for_partial_was_coverage(self):
+        selected = _gdf([{"geoid20": "A", "natwalkind": 10.0, "was_2019": 10.0, "dist_miles": 0.2}])
+        search = _gdf(
+            [
+                {"geoid20": "B", "natwalkind": 15.0, "was_2019": 13.0, "dist_miles": 1.0},
+                {"geoid20": "C", "natwalkind": 14.0, "was_2019": None, "dist_miles": 1.5},
+            ]
+        )
+
+        result = compute_upgrade_potential(
+            selected,
+            search,
+            min_delta=2.0,
+            search_radius_miles=3.0,
+        )
+
+        assert result["found"] is True
+        assert result["mode"] == UPGRADE_MODE_NWI_ONLY
+        assert [candidate["geoid20"] for candidate in result["candidates"]] == ["B", "C"]
+        assert all(candidate["delta_was"] is None for candidate in result["candidates"])
+
+    def test_compute_upgrade_potential_treats_zero_was_as_valid_score(self):
+        selected = _gdf([{"geoid20": "A", "natwalkind": 10.0, "was_2019": 0.0, "dist_miles": 0.2}])
+        search = _gdf([{"geoid20": "B", "natwalkind": 15.0, "was_2019": 2.0, "dist_miles": 1.0}])
+
+        result = compute_upgrade_potential(
+            selected,
+            search,
+            min_delta=2.0,
+            search_radius_miles=3.0,
+        )
+
+        assert result["found"] is True
+        assert result["mode"] == UPGRADE_MODE_NWI_AND_WAS
+        assert result["selected_mean_was"] == 0.0
+        assert result["candidates"][0]["delta_was"] == 2.0
 
     def test_compute_upgrade_potential_none_found_message(self):
         selected = _gdf([{"geoid20": "A", "natwalkind": 12.0, "dist_miles": 0.3}])

--- a/tests/test_profile_summary.py
+++ b/tests/test_profile_summary.py
@@ -79,6 +79,26 @@ class TestBuildSummaryFromCoords:
         assert "type" in bg0["geometry"]
         assert "coordinates" in bg0["geometry"]
 
+    def test_upgrade_potential_includes_was_when_available(self):
+        full_gdf = _sample_gdf(include_dist=True, include_was=True)
+        with patch("services.profile_summary.query_walkability_by_coords", return_value=full_gdf):
+            result = build_summary_from_coords(
+                lat=35.96,
+                lon=-83.92,
+                selected_radius_miles=1.0,
+                search_radius_miles=2.0,
+                min_delta=2.0,
+            )
+
+        upgrade = result["upgrade_potential"]
+        assert upgrade["found"] is True
+        assert upgrade["mode"] == "nwi_and_was"
+        assert upgrade["selected_mean_was"] == pytest.approx(9.0)
+        assert upgrade["min_delta_was"] == pytest.approx(2.0)
+        assert upgrade["candidates"][0]["geoid20"] == "C"
+        assert upgrade["candidates"][0]["was_2019"] == pytest.approx(24.0)
+        assert upgrade["candidates"][0]["delta_was"] == pytest.approx(15.0)
+
     def test_defaults_search_radius_to_selected_radius(self):
         full_gdf = _sample_gdf(include_dist=True)
         with patch("services.profile_summary.query_walkability_by_coords", return_value=full_gdf) as mock_query:

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -32,7 +32,7 @@ from typing import Any, get_args, get_origin
 from pydantic import BaseModel
 
 from api import schemas as api_schemas
-from api.schemas import AmenityRichnessLabel, HollowNeighborhoodLabel
+from api.schemas import AmenityRichnessLabel, HollowNeighborhoodLabel, UpgradePotentialMode
 
 TYPES_TS_PATH = Path(__file__).parent.parent / "frontend" / "src" / "types" / "api.ts"
 
@@ -49,6 +49,7 @@ _PYDANTIC_MODELS_WITHOUT_TS_COUNTERPART: set[str] = {
 _LITERAL_PAIRS: list[tuple[str, Any]] = [
     ("AmenityRichnessLabel", AmenityRichnessLabel),
     ("HollowNeighborhoodLabel", HollowNeighborhoodLabel),
+    ("UpgradePotentialMode", UpgradePotentialMode),
 ]
 
 


### PR DESCRIPTION
- Introduced a new upgrade potential mode that requires both NWI and WAS improvements for candidates.
- Updated the README to clarify the new upgrade potential criteria and fallback behavior.
- Enhanced API contract documentation to reflect changes in upgrade potential semantics.
- Modified frontend components to display both NWI and WAS improvements when applicable.
- Improved test coverage for the new upgrade potential logic, ensuring accurate validation of candidates based on WAS data.
- Bumped schema version to reflect the addition of WAS-aware upgrade potential features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the backend selection logic and API response shape for `upgrade_potential`, which can affect candidate filtering/sorting and any consumers expecting the previous NWI-only semantics. Risk is mitigated by explicit `mode` signaling plus comprehensive backend/frontend contract and UI tests.
> 
> **Overview**
> **Upgrade Potential is now WAS-aware.** When WAS data is available for the comparison, candidates must meet the existing NWI delta threshold *and* improve `was_2019` by at least `min_delta_was` (default `2.0`), and responses advertise this via `upgrade_potential.mode="nwi_and_was"`; otherwise the service explicitly falls back to `mode="nwi_only"`.
> 
> The API/TS contracts and payloads were extended to include `mode`, `selected_mean_was`, `min_delta_was`, and per-candidate `was_2019`/`delta_was`, with `SCHEMA_VERSION` bumped accordingly. The frontend `Explore`, `SummaryCards`, and `CompareTable` UIs were updated to label NWI-only vs WAS-aware results and show WAS columns/deltas when applicable, and docs/tests were updated to codify the new semantics and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e74aeba5560bf10e3a47b296bc077335f3eae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->